### PR TITLE
chore(*): auto-merge workflow 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Doeunnkimm @semnil5202 @LeeJeongHooo @Andrevile
+* @Doeunnkimm @semnil5202 @LeeJeongHooo @Andrevile @sambad-adventure

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -32,7 +32,7 @@ jobs:
           echo "MAIN_MERGE=${{ steps.check-labels.outputs.main_merge }}" >> $GITHUB_ENV
 
       - name: Auto Approve if Auto Merge Label Exists
-        if: env.AUTO_MERGE == 'true'
+        if: env.AUTO_MERGE == 'true' && env.NO_AUTO_MERGE == 'false'
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,12 +5,12 @@ on:
     types: [submitted]
 
   pull_request:
-    types: [labeled]
+    types: [labeled, unlabeled]
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.event.action == 'submitted' || github.event.action == 'labeled'
+    if: github.event.action == 'submitted' || github.event.action == 'labeled' || github.event.action == 'unlabeled'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
         with:
           github-token: ${{ secrets.PUBLIC_ACCOUNT_TOKEN }}
 
-      - name: Merge Pull Request
+      - name: Merge Pull Request on Review
         if: github.event.action == 'submitted' && github.event.review.state == 'approved' && steps.check-labels.outputs.no_auto_merge == 'false'
         uses: actions/github-script@v6
         with:
@@ -63,6 +63,36 @@ jobs:
 
             const approved = reviews.some(review => review.state === 'APPROVED');
             const targetBranch = steps.check-labels.outputs.main_merge == 'true' ? 'main' : 'dev';
+
+            if (approved) {
+              await github.rest.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                merge_method: 'squash',
+                commit_title: `Merge pull request #${context.payload.pull_request.number} into ${targetBranch}`,
+                commit_message: 'Auto-merging PR',
+                sha: context.payload.pull_request.head.sha,
+                base: targetBranch
+              });
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge Pull Request on Unlabel
+        if: github.event.action == 'unlabeled' && github.event.label.name == 'no auto merge'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const approved = reviews.some(review => review.state === 'APPROVED');
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            const targetBranch = labels.includes("main merge") ? 'main' : 'dev';
 
             if (approved) {
               await github.rest.pulls.merge({

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -25,18 +25,24 @@ jobs:
             core.setOutput("auto_merge", labels.includes("auto merge"));
             core.setOutput("main_merge", labels.includes("main merge"));
 
+      - name: Set Environment Variables
+        run: |
+          echo "NO_AUTO_MERGE=${{ steps.check-labels.outputs.no_auto_merge }}" >> $GITHUB_ENV
+          echo "AUTO_MERGE=${{ steps.check-labels.outputs.auto_merge }}" >> $GITHUB_ENV
+          echo "MAIN_MERGE=${{ steps.check-labels.outputs.main_merge }}" >> $GITHUB_ENV
+
       - name: Auto Approve if Auto Merge Label Exists
-        if: steps.check-labels.outputs.auto_merge == 'true'
+        if: env.AUTO_MERGE == 'true'
         uses: hmarr/auto-approve-action@v2.0.0
         with:
           github-token: ${{ secrets.PUBLIC_ACCOUNT_TOKEN }}
 
       - name: Merge Pull Request on Review
-        if: github.event.action == 'submitted' && github.event.review.state == 'approved' && steps.check-labels.outputs.no_auto_merge == 'false'
+        if: github.event.action == 'submitted' && github.event.review.state == 'approved' && env.NO_AUTO_MERGE == 'false'
         uses: actions/github-script@v6
         with:
           script: |
-            const targetBranch = steps.check-labels.outputs.main_merge == 'true' ? 'main' : 'dev';
+            const targetBranch = process.env.MAIN_MERGE === 'true' ? 'main' : 'dev';
             await github.rest.pulls.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -51,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge Pull Request on Label
-        if: github.event.action == 'labeled' && steps.check-labels.outputs.no_auto_merge == 'false'
+        if: github.event.action == 'labeled' && env.NO_AUTO_MERGE == 'false'
         uses: actions/github-script@v6
         with:
           script: |
@@ -62,7 +68,7 @@ jobs:
             });
 
             const approved = reviews.some(review => review.state === 'APPROVED');
-            const targetBranch = steps.check-labels.outputs.main_merge == 'true' ? 'main' : 'dev';
+            const targetBranch = process.env.MAIN_MERGE === 'true' ? 'main' : 'dev';
 
             if (approved) {
               await github.rest.pulls.merge({

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
           script: |
             const labels = context.payload.pull_request.labels.map(label => label.name);
             core.setOutput("no_auto_merge", labels.includes("no auto merge"));
-            core.setOutput("auto_merge", labels.includes("auto merge"));
+            core.setOutput("auto_merge", labels.includes("auto approve"));
             core.setOutput("main_merge", labels.includes("main merge"));
 
       - name: Set Environment Variables

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,6 +23,7 @@ jobs:
             const labels = context.payload.pull_request.labels.map(label => label.name);
             core.setOutput("no_auto_merge", labels.includes("no auto merge"));
             core.setOutput("auto_merge", labels.includes("auto merge"));
+            core.setOutput("main_merge", labels.includes("main merge"));
 
       - name: Auto Approve if Auto Merge Label Exists
         if: steps.check-labels.outputs.auto_merge == 'true'
@@ -35,11 +36,16 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            const targetBranch = steps.check-labels.outputs.main_merge == 'true' ? 'main' : 'dev';
             await github.rest.pulls.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              merge_method: 'squash'
+              merge_method: 'squash',
+              commit_title: `Merge pull request #${context.payload.pull_request.number} into ${targetBranch}`,
+              commit_message: 'Auto-merging PR',
+              sha: context.payload.pull_request.head.sha,
+              base: targetBranch
             });
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -56,13 +62,18 @@ jobs:
             });
 
             const approved = reviews.some(review => review.state === 'APPROVED');
+            const targetBranch = steps.check-labels.outputs.main_merge == 'true' ? 'main' : 'dev';
 
             if (approved) {
               await github.rest.pulls.merge({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: context.payload.pull_request.number,
-                merge_method: 'squash'
+                merge_method: 'squash',
+                commit_title: `Merge pull request #${context.payload.pull_request.number} into ${targetBranch}`,
+                commit_message: 'Auto-merging PR',
+                sha: context.payload.pull_request.head.sha,
+                base: targetBranch
               });
             }
         env:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -33,9 +33,18 @@ jobs:
 
       - name: Auto Approve if Auto Merge Label Exists
         if: env.AUTO_MERGE == 'true'
-        uses: hmarr/auto-approve-action@v2.0.0
+        uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.PUBLIC_ACCOUNT_TOKEN }}
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE',
+              body: '고생했다. 👍🏽'
+            });
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge Pull Request on Review
         if: github.event.action == 'submitted' && github.event.review.state == 'approved' && env.NO_AUTO_MERGE == 'false'

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -44,7 +44,7 @@ jobs:
               body: '고생했다. 👍🏽'
             });
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_ACCOUNT_TOKEN }}
 
       - name: Merge Pull Request on Review
         if: |

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,69 @@
+name: Auto Merge PR
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+  pull_request:
+    types: [labeled]
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'submitted' || github.event.action == 'labeled'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Check Labels
+        id: check-labels
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            core.setOutput("no_auto_merge", labels.includes("no auto merge"));
+            core.setOutput("auto_merge", labels.includes("auto merge"));
+
+      - name: Auto Approve if Auto Merge Label Exists
+        if: steps.check-labels.outputs.auto_merge == 'true'
+        uses: hmarr/auto-approve-action@v2.0.0
+        with:
+          github-token: ${{ secrets.PUBLIC_ACCOUNT_TOKEN }}
+
+      - name: Merge Pull Request
+        if: github.event.action == 'submitted' && github.event.review.state == 'approved' && steps.check-labels.outputs.no_auto_merge == 'false'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              merge_method: 'squash'
+            });
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge Pull Request on Label
+        if: github.event.action == 'labeled' && steps.check-labels.outputs.no_auto_merge == 'false'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const approved = reviews.some(review => review.state === 'APPROVED');
+
+            if (approved) {
+              await github.rest.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                merge_method: 'squash'
+              });
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.event.action == 'submitted' || github.event.action == 'labeled' || github.event.action == 'unlabeled'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -47,7 +47,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge Pull Request on Review
-        if: github.event.action == 'submitted' && github.event.review.state == 'approved' && env.NO_AUTO_MERGE == 'false'
+        if: |
+          github.event_name == 'pull_request_review' &&
+          github.event.review.state == 'approved' &&
+          env.NO_AUTO_MERGE == 'false'
         uses: actions/github-script@v6
         with:
           script: |
@@ -66,7 +69,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge Pull Request on Label
-        if: github.event.action == 'labeled' && env.NO_AUTO_MERGE == 'false'
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.action == 'labeled' &&
+          env.NO_AUTO_MERGE == 'false'
         uses: actions/github-script@v6
         with:
           script: |
@@ -95,7 +101,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge Pull Request on Unlabel
-        if: github.event.action == 'unlabeled' && github.event.label.name == 'no auto merge'
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.action == 'unlabeled' &&
+          github.event.label.name == 'no auto merge'
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
## 🎉 변경 사항

- `approve`를 하나 받으면: auto merge가 됩니다.
  - 기본적으로 dev 브랜치로 머지되며
  - `main merge` 라벨을 선택하면 main 브랜치로 자동 머지가 됩니다.
- `no auto merge` 라벨을 붙이면
  - approve가 존재해도 머지 되지 않습니다.
  - 중간에 라벨을 떼면 오토 머지 워크플로우가 동작됩니다.
- `auto approve` 라벨을 붙이면
  - 공용 계정이 나타나 approve → 오토 머지 워크 플로우가 동작합니다.

## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!

이거 테스트 필요해요 🚨 
gpt야 고맙다
