### PR TITLE
chore(*): post-merge 스크립트 변경

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,12 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-current_branch=$(git symbolic-ref --short HEAD)
-changed_files=$(git diff --name-only origin/$current_branch)
-
-if echo "$changed_files" | grep -E 'package\.json|packages/*/package\.json|apps/*/package\.json|pnpm-workspace\.yaml|pnpm-lock\.yaml' > /dev/null 2>&1; then
-  echo "패키지 파일 변경 사항이 감지되었습니다. pnpm install을 실행합니다."
-  pnpm install
-else
-  echo "패키지 파일 변경 사항이 없습니다."
-fi
+pnpm install

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "type-check": "turbo run type-check",
     "check:spell": "cspell '**' --gitignore --no-progress",
-    "postinstall": "husky install",
     "generate:package": "turbo gen package-template"
   },
   "dependencies": {


### PR DESCRIPTION
## 🎉 변경 사항

* 모든 브랜치에 대해서 pull 시 pnpm install 수행
* postinstall 스크립트(husky install)는 확인해본 결과 목표한 것과는 관련이 없어 제거함

이제 모든 브랜치를 대상으로 git pull 시 pnpm install을 수행합니다.

이렇게 변경한 이유는 디버깅을 할 수 있는 환경을 마련하기가 너무 까다로워서 (패키지 의존성 변경 -> origin main에 반영 -> 다시 내 로컬로 pull) 입니다.

의존성 변경이 없다면 pnpm install을 실행해도 1초 이내로 마무리 되므로, 그리고 git pull을 자주 하지는 않으므로, 위와 같이 변경했습니다.

## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
