### PR TITLE
feat(sds): Txt 컴포넌트 추가

### DIFF
--- a/packages/core/sds/package.json
+++ b/packages/core/sds/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "exports": {
     ".": "./src/index.ts",
-    "./theme": "./src/theme/index.ts"
+    "./theme": "./src/theme/index.ts",
+    "./components": "./src/components/index.ts"
   },
   "scripts": {
     "lint": "eslint . --max-warnings 0",

--- a/packages/core/sds/src/components/Typography/Txt.tsx
+++ b/packages/core/sds/src/components/Typography/Txt.tsx
@@ -27,13 +27,12 @@ export const Txt = forwardRef<HTMLSpanElement, TxtProps>((props, ref) => {
   const color = colorFromProps ?? colors.grey700;
   const fontWeight = fontWeightFromProps ?? fontWeightVariants[fontWeightByTypography[typography]];
   const fontSize = fontSizeByTypography[typography];
-  const lineHeight = lineHeightByTypography[typography];
 
   const style = {
     color,
     fontWeight,
     fontSize,
-    lineHeight,
+    lineHeight: '150%',
     ...styleFromProps,
   };
 

--- a/packages/core/sds/src/components/Typography/Txt.tsx
+++ b/packages/core/sds/src/components/Typography/Txt.tsx
@@ -7,7 +7,7 @@ import { fontSizeByTypography, fontWeightVariants, fontWeightByTypography, lineH
  * @TODO
  * Polymorphic하게 만들기
  */
-interface TxtProps extends HTMLAttributes<HTMLSpanElement> {
+export interface TxtProps extends HTMLAttributes<HTMLSpanElement> {
   as?: ElementType;
   color?: string;
   typography?: Typography;

--- a/packages/core/sds/src/components/Typography/Txt.tsx
+++ b/packages/core/sds/src/components/Typography/Txt.tsx
@@ -1,0 +1,41 @@
+import { ElementType, forwardRef, HTMLAttributes } from 'react';
+import { colors, size } from '../../theme';
+import { FontWeight, Typography } from './types';
+import { fontSizeByTypography, fontWeightVariants, fontWeightByTypography, lineHeightByTypography } from './styles';
+
+/**
+ * @TODO
+ * Polymorphic하게 만들기
+ */
+interface TxtProps extends HTMLAttributes<HTMLSpanElement> {
+  as?: ElementType;
+  color?: string;
+  typography?: Typography;
+  fontWeight?: FontWeight;
+}
+
+export const Txt = forwardRef<HTMLSpanElement, TxtProps>((props, ref) => {
+  const {
+    as: Tag = 'span',
+    color: colorFromProps,
+    typography = 'body2',
+    fontWeight: fontWeightFromProps,
+    style: styleFromProps,
+    ...restProps
+  } = props;
+
+  const color = colorFromProps ?? colors.grey700;
+  const fontWeight = fontWeightFromProps ?? fontWeightVariants[fontWeightByTypography[typography]];
+  const fontSize = fontSizeByTypography[typography];
+  const lineHeight = lineHeightByTypography[typography];
+
+  const style = {
+    color,
+    fontWeight,
+    fontSize,
+    lineHeight,
+    ...styleFromProps,
+  };
+
+  return <Tag ref={ref} style={style} {...restProps} />;
+});

--- a/packages/core/sds/src/components/Typography/Txt.tsx
+++ b/packages/core/sds/src/components/Typography/Txt.tsx
@@ -1,7 +1,7 @@
 import { ElementType, forwardRef, HTMLAttributes } from 'react';
-import { colors, size } from '../../theme';
+import { colors } from '../../theme';
 import { FontWeight, Typography } from './types';
-import { fontSizeByTypography, fontWeightVariants, fontWeightByTypography, lineHeightByTypography } from './styles';
+import { fontSizeByTypography, fontWeightVariants, fontWeightByTypography } from './styles';
 
 /**
  * @TODO

--- a/packages/core/sds/src/components/Typography/index.ts
+++ b/packages/core/sds/src/components/Typography/index.ts
@@ -1,0 +1,3 @@
+export { Txt } from './Txt';
+export { fontWeightVariants } from './styles';
+export type { Typography, FontWeight } from './types';

--- a/packages/core/sds/src/components/Typography/index.ts
+++ b/packages/core/sds/src/components/Typography/index.ts
@@ -1,3 +1,5 @@
 export { Txt } from './Txt';
+export type { TxtProps } from './Txt';
+
 export { fontWeightVariants } from './styles';
 export type { Typography, FontWeight } from './types';

--- a/packages/core/sds/src/components/Typography/styles.ts
+++ b/packages/core/sds/src/components/Typography/styles.ts
@@ -24,28 +24,6 @@ export const fontSizeByTypography: Record<Typography, string> = {
   body5: '8px',
 };
 
-/**
- * @TODO
- * 새로운 가이드 적용해야 함..
- * 현재 이상함 !
- */
-export const lineHeightByTypography: Record<Typography, number> = {
-  heading1: 32,
-  heading2: 28,
-  heading3: 24,
-  title1: 28,
-  title2: 24,
-  title3: 20,
-  title4: 20,
-  subtitle1: 24,
-  subTitle2: 20,
-  body1: 28,
-  body2: 24,
-  body3: 20,
-  body4: 20,
-  body5: 16,
-};
-
 export const fontWeightByTypography: Record<Typography, FontWeight> = {
   heading1: 'bold',
   heading2: 'bold',

--- a/packages/core/sds/src/components/Typography/styles.ts
+++ b/packages/core/sds/src/components/Typography/styles.ts
@@ -1,0 +1,64 @@
+import { FontWeight, Typography } from './types';
+
+export const fontWeightVariants: Record<FontWeight, number> = {
+  regular: 400,
+  medium: 500,
+  semibold: 600,
+  bold: 700,
+};
+
+export const fontSizeByTypography: Record<Typography, string> = {
+  heading1: '24px',
+  heading2: '20px',
+  heading3: '16px',
+  title1: '20px',
+  title2: '16px',
+  title3: '14px',
+  title4: '12px',
+  subtitle1: '16px',
+  subTitle2: '14px',
+  body1: '20px',
+  body2: '16px',
+  body3: '14px',
+  body4: '12px',
+  body5: '8px',
+};
+
+/**
+ * @TODO
+ * 새로운 가이드 적용해야 함..
+ * 현재 이상함 !
+ */
+export const lineHeightByTypography: Record<Typography, number> = {
+  heading1: 32,
+  heading2: 28,
+  heading3: 24,
+  title1: 28,
+  title2: 24,
+  title3: 20,
+  title4: 20,
+  subtitle1: 24,
+  subTitle2: 20,
+  body1: 28,
+  body2: 24,
+  body3: 20,
+  body4: 20,
+  body5: 16,
+};
+
+export const fontWeightByTypography: Record<Typography, FontWeight> = {
+  heading1: 'bold',
+  heading2: 'bold',
+  heading3: 'bold',
+  title1: 'medium',
+  title2: 'medium',
+  title3: 'medium',
+  title4: 'medium',
+  subtitle1: 'semibold',
+  subTitle2: 'semibold',
+  body1: 'regular',
+  body2: 'regular',
+  body3: 'regular',
+  body4: 'regular',
+  body5: 'regular',
+};

--- a/packages/core/sds/src/components/Typography/types.ts
+++ b/packages/core/sds/src/components/Typography/types.ts
@@ -1,0 +1,17 @@
+export type Typography =
+  | 'heading1'
+  | 'heading2'
+  | 'heading3'
+  | 'title1'
+  | 'title2'
+  | 'title3'
+  | 'title4'
+  | 'subtitle1'
+  | 'subTitle2'
+  | 'body1'
+  | 'body2'
+  | 'body3'
+  | 'body4'
+  | 'body5';
+
+export type FontWeight = 'regular' | 'medium' | 'semibold' | 'bold';

--- a/packages/core/sds/src/components/index.ts
+++ b/packages/core/sds/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './Typography';


### PR DESCRIPTION
## 🎉 변경 사항

[가이드](https://www.figma.com/design/K0vbFsWUNzQXl5NRGra2m9/%5BDPM%5D-3%ED%8C%80%F0%9F%A7%91%E2%80%8D%F0%9F%9A%80?node-id=2531-51928&t=r2Chxfr0bm0yDqnB-11)에 맞춰 Txt 컴포넌트를 추가합니다.

### ✔️ Usage

```tsx
// Usage
<Txt as="p" typography="title1" fontWeight="regular" color={colors.primary200}>삼봤뜨</Txt>
```

### ✔️ Default value

잘 확인하시고 default 값을 사용하게 될 때 prop을 넘기지 않도록 합시다 !

- typography: `'body2'` (*커스텀 가능)
- color: `colors.grey700` (*커스텀 가능)
- fontWeight: `typography prop을 따라가도록` (*커스텀 가능)
- fontSize: `typography prop을 따라가도록`
- lineHeight: `typography prop을 따라가도록`

color랑 fontWeight는 사용처에서 커스텀이 필요할 경우가 많아서 커스텀 가능하도록 열어두었습니다~
(fontWeight는 .. 호버 한다던가 select 되었을 때 bold 처리하는 경우가 많은 것 같아요)

### ✔️ Polymorphic 하게 수정하기

다형성 컴포넌트로 만드려다가 실패해서.. 우선은 `as` prop은 먹지만 타입은 매핑되지 않습니다...
기본적인 것들만 사용한다면 당장은 크게 문제 없을 거 같아요!

리소스 남을 때 다시 디깅해보겠습니다




## 🔗 링크

[SAMBAD-120](https://www.notion.so/depromeet/Typography-366ddc9aa3ec4c6fa0e13455be684a1c?pvs=4)

#### 🙏 여기는 꼭 봐주세요!
