### PR TITLE
feat(sds): TextButton 구현

### DIFF
--- a/packages/core/sds/src/components/TextButton/TextButton.tsx
+++ b/packages/core/sds/src/components/TextButton/TextButton.tsx
@@ -1,0 +1,32 @@
+import { ButtonHTMLAttributes, Children, forwardRef } from 'react';
+import { TextButtonVariant } from './types';
+import { Icon } from '../Icon';
+import { arrowIconCss, textButtonCss } from './styles';
+import { colors } from '../../theme';
+
+export interface TextButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: TextButtonVariant;
+  color?: string;
+}
+
+export const TextButton = forwardRef<HTMLButtonElement, TextButtonProps>((props, ref) => {
+  const { variant = 'normal', color = colors.grey600, style: styleFromProps, children, ...restProps } = props;
+
+  const isUnderlineVariant = variant === 'underline';
+  const isArrowVariant = variant === 'arrow';
+
+  const style = {
+    color,
+    ...(isUnderlineVariant && { textDecoration: 'underline' }),
+    ...styleFromProps,
+  };
+
+  return (
+    <button ref={ref} style={style} css={textButtonCss} {...restProps}>
+      {children}
+      {isArrowVariant && <Icon css={arrowIconCss} color={color} name="angle-right" />}
+    </button>
+  );
+});
+
+TextButton.displayName = 'TextButton';

--- a/packages/core/sds/src/components/TextButton/TextButton.tsx
+++ b/packages/core/sds/src/components/TextButton/TextButton.tsx
@@ -24,7 +24,7 @@ export const TextButton = forwardRef<HTMLButtonElement, TextButtonProps>((props,
   return (
     <button ref={ref} style={style} css={textButtonCss} {...restProps}>
       {children}
-      {isArrowVariant && <Icon css={arrowIconCss} color={color} name="angle-right" />}
+      {isArrowVariant && <Icon css={arrowIconCss} color={color} size={12} name="angle-right" />}
     </button>
   );
 });

--- a/packages/core/sds/src/components/TextButton/index.ts
+++ b/packages/core/sds/src/components/TextButton/index.ts
@@ -1,0 +1,4 @@
+export { TextButton } from './TextButton';
+export type { TextButtonProps } from './TextButton';
+
+export type { TextButtonVariant } from './types';

--- a/packages/core/sds/src/components/TextButton/styles.ts
+++ b/packages/core/sds/src/components/TextButton/styles.ts
@@ -1,0 +1,23 @@
+import { css } from '@emotion/react';
+import { colors } from '../../theme';
+
+export const textButtonCss = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+
+  cursor: 'pointer',
+  lineHeight: '150%',
+
+  '&:disabled': {
+    cursor: 'not-allowed',
+    opacity: 0.4,
+  },
+});
+
+export const arrowIconCss = css({
+  marginLeft: '4px',
+
+  '& svg': {
+    width: '12px',
+  },
+});

--- a/packages/core/sds/src/components/TextButton/styles.ts
+++ b/packages/core/sds/src/components/TextButton/styles.ts
@@ -6,6 +6,7 @@ export const textButtonCss = css({
   alignItems: 'center',
 
   cursor: 'pointer',
+  fontSize: '12px',
   lineHeight: '150%',
 
   '&:disabled': {

--- a/packages/core/sds/src/components/TextButton/styles.ts
+++ b/packages/core/sds/src/components/TextButton/styles.ts
@@ -16,8 +16,4 @@ export const textButtonCss = css({
 
 export const arrowIconCss = css({
   marginLeft: '4px',
-
-  '& svg': {
-    width: '12px',
-  },
 });

--- a/packages/core/sds/src/components/TextButton/types.ts
+++ b/packages/core/sds/src/components/TextButton/types.ts
@@ -1,0 +1,1 @@
+export type TextButtonVariant = 'normal' | 'underline' | 'arrow';

--- a/packages/core/sds/src/components/index.ts
+++ b/packages/core/sds/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './Typography';
 export * from './Icon';
 export * from './Button';
+export * from './TextButton';


### PR DESCRIPTION
## 🎉 변경 사항

#### 🚨 최소한의 스타일이 담겨져 있습니다.. 추후 추가 스타일링과 리팩터링 예정 !

텍스트 형태의 버튼 기능을 사용해야 할 때 활용될 컴포넌트입니다.

### ✔️ Usage

```tsx
<TextButton variant="normal | underline | arrow" color={colors.grey200}>TEXTBUTTON</TextButton>
```

### ✔️ variant

underline

![image](https://github.com/user-attachments/assets/ceb0b57c-a427-4d07-8393-fe85a5fb0070)

arrow

![image](https://github.com/user-attachments/assets/da55d968-f3f5-4b43-b6fc-a04577c117a0)

normal (default)

![image](https://github.com/user-attachments/assets/0d4062cf-8f14-4a08-ba54-cac9dc525f41)

### 🤔 Txt랑 뭐가 다른건가요?

button 엘리먼트 속성을 사용할 수 있고, hover시 `cursor: 'pointer'`로 구분감이 있으며, 여러 variant를 제공해요


## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
