### PR TITLE
fix(sds): Txt 컴포넌트 fontWeight 오류

### DIFF
--- a/packages/core/sds/src/components/Typography/Txt.tsx
+++ b/packages/core/sds/src/components/Typography/Txt.tsx
@@ -27,7 +27,7 @@ export const Txt = forwardRef<HTMLSpanElement, TxtProps>((props, ref) => {
   } = props;
 
   const color = colorFromProps ?? colors.grey700;
-  const fontWeight = fontWeightFromProps ?? fontWeightVariants[fontWeightByTypography[typography]];
+  const fontWeight = fontWeightVariants[fontWeightFromProps ?? fontWeightByTypography[typography]];
   const fontSize = fontSizeByTypography[typography];
 
   const style = {


### PR DESCRIPTION
## 🎉 변경 사항

Txt 컴포넌트의 fontWeight prop이 동작하지 않는 문제를 해결합니다.

| as-is | to-be |
|:--:|:--:|
| ![image](https://github.com/user-attachments/assets/b0fa459c-69dc-4315-8579-353a2285f477) |  ![image](https://github.com/user-attachments/assets/8d0ea622-8c4d-4fc8-ada7-eea02b8addb0) |

## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
