### PR TITLE
fix: 커스텀 useQueryOPtions global declare 해제

### DIFF
--- a/packages/core/eslint-config/base.js
+++ b/packages/core/eslint-config/base.js
@@ -8,7 +8,6 @@ module.exports = {
   globals: {
     React: true,
     JSX: true,
-    UseQueryOptionsExcludedQueryKey: 'readonly',
   },
   settings: {
     'import/extensions': ['.js', '.jsx', '.ts', '.tsx'],

--- a/packages/core/types-utils/tanstack/index.d.ts
+++ b/packages/core/types-utils/tanstack/index.d.ts
@@ -1,5 +1,3 @@
 import { UseQueryOptions } from '@tanstack/react-query';
 
-declare global {
-  type UseQueryOptionsExcludedQueryKey<T, K = T> = Omit<UseQueryOptions<T, unknown, K>, 'queryKey'>;
-}
+export type UseQueryOptionsExcludedQueryKey<T, K = T> = Omit<UseQueryOptions<T, unknown, K>, 'queryKey'>;

--- a/packages/core/typescript-config/base.json
+++ b/packages/core/typescript-config/base.json
@@ -16,6 +16,6 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2022",
-    "types": ["@emotion/react/types/css-prop", "@sambad/types-utils/tanstack"]
+    "types": ["@emotion/react/types/css-prop"]
   }
 }


### PR DESCRIPTION
## 🎉 변경 사항
핫픽스입니다.global로 선언하니 의존성관리가 힘들어져서, push할때, 정확히 찾기가 힘드네요
강제로 머지하겠습니다.
## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
