### PR TITLE
refactor(types-utils): UseQueryOptionsWithAxios 유틸 타입 추가

### DIFF
--- a/packages/core/types-utils/package.json
+++ b/packages/core/types-utils/package.json
@@ -13,6 +13,7 @@
     "@turbo/gen": "^1.12.4",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
+    "axios": "^1.7.2",
     "eslint": "^8.57.0",
     "eslint-plugin-storybook": "^0.8.0",
     "typescript": "^5.3.3"

--- a/packages/core/types-utils/tanstack/index.d.ts
+++ b/packages/core/types-utils/tanstack/index.d.ts
@@ -1,4 +1,3 @@
 import { UseQueryOptions } from '@tanstack/react-query';
-import { AxiosResponse } from 'axios';
 
-export type UseQueryOptionsExcludedQueryKey<T> = Omit<UseQueryOptions<AxiosResponse<T>, unknown, T>, 'queryKey'>;
+export type UseQueryOptionsExcludedQueryKey<T, K = T> = Omit<UseQueryOptions<T, unknown, K>, 'queryKey'>;

--- a/packages/core/types-utils/tanstack/index.d.ts
+++ b/packages/core/types-utils/tanstack/index.d.ts
@@ -1,3 +1,4 @@
 import { UseQueryOptions } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
 
-export type UseQueryOptionsExcludedQueryKey<T, K = T> = Omit<UseQueryOptions<T, unknown, K>, 'queryKey'>;
+export type UseQueryOptionsExcludedQueryKey<T> = Omit<UseQueryOptions<AxiosResponse<T>, unknown, T>, 'queryKey'>;

--- a/packages/core/types-utils/tanstack/index.d.ts
+++ b/packages/core/types-utils/tanstack/index.d.ts
@@ -3,4 +3,4 @@ import { AxiosResponse } from 'axios';
 
 export type UseQueryOptionsExcludedQueryKey<T, K = T> = Omit<UseQueryOptions<T, unknown, K>, 'queryKey'>;
 
-export type UseQueryOptionsWithAxios<T, K = T> = UseQueryOptionsExcludedQueryKey<AxiosResponse<T>, T>;
+export type UseQueryOptionsWithAxios<T, K = T> = UseQueryOptionsExcludedQueryKey<AxiosResponse<T>, K>;

--- a/packages/core/types-utils/tanstack/index.d.ts
+++ b/packages/core/types-utils/tanstack/index.d.ts
@@ -3,4 +3,4 @@ import { AxiosResponse } from 'axios';
 
 export type UseQueryOptionsExcludedQueryKey<T, K = T> = Omit<UseQueryOptions<T, unknown, K>, 'queryKey'>;
 
-export type UseQueryOptionsWithAxios<T> = UseQueryOptions<AxiosResponse<T>, unknown, T>;
+export type UseQueryOptionsWithAxios<T> = UseQueryOptionsExcludedQueryKey<AxiosResponse<T>, unknown, T>;

--- a/packages/core/types-utils/tanstack/index.d.ts
+++ b/packages/core/types-utils/tanstack/index.d.ts
@@ -1,3 +1,6 @@
 import { UseQueryOptions } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
 
 export type UseQueryOptionsExcludedQueryKey<T, K = T> = Omit<UseQueryOptions<T, unknown, K>, 'queryKey'>;
+
+export type UseQueryOptionsWithAxios<T> = UseQueryOptions<AxiosResponse<T>, unknown, T>;

--- a/packages/core/types-utils/tanstack/index.d.ts
+++ b/packages/core/types-utils/tanstack/index.d.ts
@@ -3,4 +3,4 @@ import { AxiosResponse } from 'axios';
 
 export type UseQueryOptionsExcludedQueryKey<T, K = T> = Omit<UseQueryOptions<T, unknown, K>, 'queryKey'>;
 
-export type UseQueryOptionsWithAxios<T> = UseQueryOptionsExcludedQueryKey<AxiosResponse<T>, unknown, T>;
+export type UseQueryOptionsWithAxios<T, K = T> = UseQueryOptionsExcludedQueryKey<AxiosResponse<T>, T>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       '@types/node':
         specifier: ^20.11.24
         version: 20.14.10
+      axios:
+        specifier: ^1.7.2
+        version: 1.7.2
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -5095,7 +5098,6 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: false
 
   /available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -5117,7 +5119,6 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
-    dev: false
 
   /axobject-query@3.1.1:
     resolution: {integrity: sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==}
@@ -5677,7 +5678,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: false
 
   /commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
@@ -6224,7 +6224,6 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: false
 
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -7566,7 +7565,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: false
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -7612,7 +7610,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: false
 
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}


### PR DESCRIPTION
## 🎉 변경 사항

하나의 타입을 제네릭의 2개의 인자에 동일하게 넘겨주고 있어서, 하나의 인자로 전달해도 문제 없도록 리팩터링 했어요

👇 기존 코드에서 하나의 인자만 넘겨주었을 때

![image](https://github.com/user-attachments/assets/bb29059c-bc9f-407f-8ab4-07d640968c75)

### ✔️ Usage

```
options: UseQueryOptionsExcludedQueryKey<FooResponse>
```


## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
