### PR TITLE
chore: eslint no-undef 옵션 끔

### DIFF
--- a/packages/core/eslint-config/base.js
+++ b/packages/core/eslint-config/base.js
@@ -37,6 +37,7 @@ module.exports = {
         ignoreExternal: true,
       },
     ],
+    'no-undef': 'off',
     'no-duplicate-imports': 'error',
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'error',


### PR DESCRIPTION
## 🎉 변경 사항
no-undef 룰을 off합니다


why?
전역적으로 선언되어있는 타입조차 undefined되어있다고 에러를 내뿜내요.(사진 1)
애초에 코드상에 정의가 되어있지 않은 걸 참조할 때, 해당 에러를 내뿜는거 같은데, 저 룰을 꺼도 그건 에러가 나오네요(사진 3)
![스크린샷 2024-07-28 오후 10 10 02](https://github.com/user-attachments/assets/0e1b86a1-2661-492a-be0e-9f4266fef5cc)
![스크린샷 2024-07-28 오후 10 10 14](https://github.com/user-attachments/assets/6c19c4db-11a8-4c24-9890-981f28550eac)
![스크린샷 2024-07-28 오후 10 10 37](https://github.com/user-attachments/assets/c764c7a5-1b0c-452d-92a8-7c3c38dff8bf)


## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
