### PR TITLE
feat(sds): Button hover 컬러 설정 및 leftDecor 스펙 추가

### DIFF
--- a/packages/core/sds/src/components/Button/Button.tsx
+++ b/packages/core/sds/src/components/Button/Button.tsx
@@ -1,15 +1,24 @@
-import { ButtonHTMLAttributes, forwardRef } from 'react';
+import { ButtonHTMLAttributes, forwardRef, ReactNode } from 'react';
 
-import { buttonCss, buttonDisabledVariants, buttonSizeVariants, buttonVariantVariants } from './styles';
+import { buttonCss, buttonDisabledVariants, buttonSizeVariants, buttonVariantVariants, leftDecorCss } from './styles';
 import { ButtonSize, ButtonVariant } from './types';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   size?: ButtonSize;
   variant?: ButtonVariant;
+  leftDecor?: ReactNode;
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
-  const { variant = 'primary', size = 'medium', disabled = false, style: styleFromProps, ...restProps } = props;
+  const {
+    variant = 'primary',
+    size = 'medium',
+    disabled = false,
+    style: styleFromProps,
+    leftDecor,
+    children,
+    ...restProps
+  } = props;
 
   const style = {
     ...buttonSizeVariants[size],
@@ -18,7 +27,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) =>
     ...styleFromProps,
   };
 
-  return <button ref={ref} disabled={disabled} style={style} css={buttonCss} {...restProps} />;
+  return (
+    <button ref={ref} disabled={disabled} style={style} css={buttonCss} {...restProps}>
+      {leftDecor != null && <span css={leftDecorCss}>{leftDecor}</span>}
+      {children}
+    </button>
+  );
 });
 
 Button.displayName = 'Button';

--- a/packages/core/sds/src/components/Button/styles.ts
+++ b/packages/core/sds/src/components/Button/styles.ts
@@ -2,6 +2,8 @@ import { css } from '@emotion/react';
 
 import { borderRadiusVariants, colors } from '@sds/theme';
 
+import { fontWeightVariants } from '../Typography';
+
 import { ButtonSize, ButtonVariant } from './types';
 
 const buttonHeightVar = '--sambad-button-height';
@@ -26,11 +28,13 @@ export const buttonSizeVariants: Record<ButtonSize, ButtonSizeVariants> = {
 const buttonBackgroundColorVar = '--sambad-button-background-color';
 const buttonBorderVar = '--sambad-button-border';
 const buttonColorVar = '--sambad-button-color';
+const buttonHoverColorVar = '--sambad-button-hover-color';
 
 interface ButtonVariantVariants {
   [buttonBackgroundColorVar]: string;
   [buttonBorderVar]: string;
   [buttonColorVar]: string;
+  [buttonHoverColorVar]?: string;
 }
 
 export const buttonVariantVariants: Record<ButtonVariant, ButtonVariantVariants> = {
@@ -38,11 +42,13 @@ export const buttonVariantVariants: Record<ButtonVariant, ButtonVariantVariants>
     [buttonBackgroundColorVar]: colors.black,
     [buttonBorderVar]: 'none',
     [buttonColorVar]: colors.white,
+    [buttonHoverColorVar]: colors.grey700,
   },
   sub: {
     [buttonBackgroundColorVar]: colors.white,
     [buttonBorderVar]: `1px solid ${colors.grey500}`,
     [buttonColorVar]: colors.black,
+    [buttonHoverColorVar]: colors.grey300,
   },
 };
 
@@ -62,6 +68,7 @@ export const buttonDisabledVariants: Record<ButtonVariant, ButtonVariantVariants
 export const buttonCss = css({
   width: '100%',
   height: `var(${buttonHeightVar})`,
+  transition: 'background-color 0.3s ease',
 
   display: 'flex',
   justifyContent: 'center',
@@ -70,12 +77,17 @@ export const buttonCss = css({
   color: `var(${buttonColorVar})`,
   fontSize: `var(${buttonFontSizeVar})`,
   lineHeight: '150%',
+  fontWeight: fontWeightVariants.semibold,
 
   border: `var(${buttonBorderVar})`,
   borderRadius: borderRadiusVariants.round,
   backgroundColor: `var(${buttonBackgroundColorVar})`,
 
   cursor: 'pointer',
+
+  '&:hover': {
+    backgroundColor: `var(${buttonHoverColorVar})`,
+  },
 
   '&:disabled': {
     cursor: 'not-allowed',

--- a/packages/core/sds/src/components/Button/styles.ts
+++ b/packages/core/sds/src/components/Button/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import { borderRadiusVariants, colors } from '@sds/theme';
+import { borderRadiusVariants, colors, size } from '@sds/theme';
 
 import { fontWeightVariants } from '../Typography';
 
@@ -91,5 +91,17 @@ export const buttonCss = css({
 
   '&:disabled': {
     cursor: 'not-allowed',
+  },
+});
+
+export const leftDecorCss = css({
+  display: 'inline-flex',
+  marginRight: size['6xs'],
+
+  // NOTE: icon
+  '& svg, & path': {
+    width: 20,
+    height: 20,
+    fill: `var(${buttonColorVar})`,
   },
 });


### PR DESCRIPTION
## 🎉 변경 사항

- font-weight fix (medium -> semibold)
- hover 컬러 추가
- `leftDecor` 스펙 추가

```tsx
<Button leftDecor={<Icon name="foo" />}>BUTTON</Button>
```

^ 와 같이 사용하시면 `여백`, `사이즈`, `컬러`가 버튼 스펙에 맞게 적용됩니다.

https://github.com/user-attachments/assets/a96fe3f0-fa98-4ef2-946d-c8f3a8a20079

### ✔️ Decor 정의

sds에서는 악세서리류 네이밍을 `Decor`을 사용하려고 합니다 ~!

## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
