### PR TITLE
feat(sds): Loader 컴포넌트 추가

### DIFF
--- a/packages/core/sds/src/components/Loader/Loader.tsx
+++ b/packages/core/sds/src/components/Loader/Loader.tsx
@@ -1,0 +1,24 @@
+import { forwardRef, ImgHTMLAttributes } from 'react';
+
+import { containerModeAttribute } from './constants';
+import { containerCss } from './styles';
+import { LoaderMode } from './types';
+
+const loadingImageUrl = 'https://file.moring.one/defaults/loading.png';
+
+export interface LoaderProps extends ImgHTMLAttributes<HTMLImageElement> {
+  size?: number;
+  mode?: LoaderMode;
+}
+
+export const Loader = forwardRef<HTMLImageElement, LoaderProps>((props, ref) => {
+  const { size = 60, mode = 'dim', ...restProps } = props;
+
+  return (
+    <div css={containerCss} {...containerModeAttribute.attribute(mode)}>
+      <img ref={ref} src={loadingImageUrl} width={size} height={size} alt="loading" {...restProps} />
+    </div>
+  );
+});
+
+Loader.displayName = 'Loader';

--- a/packages/core/sds/src/components/Loader/constants.ts
+++ b/packages/core/sds/src/components/Loader/constants.ts
@@ -1,0 +1,11 @@
+import { LoaderMode } from './types';
+
+type ModeType = LoaderMode;
+
+const containerModeAttributeKey = 'data-loader-container-mode';
+export const containerModeAttribute = {
+  attribute: (mode: ModeType) => ({
+    [containerModeAttributeKey]: mode,
+  }),
+  querySelector: (mode: ModeType) => `[${containerModeAttributeKey}=${mode}]`,
+};

--- a/packages/core/sds/src/components/Loader/index.ts
+++ b/packages/core/sds/src/components/Loader/index.ts
@@ -1,0 +1,4 @@
+export { Loader } from './Loader';
+export type { LoaderProps } from './Loader';
+
+export type { LoaderMode } from './types';

--- a/packages/core/sds/src/components/Loader/styles.ts
+++ b/packages/core/sds/src/components/Loader/styles.ts
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react';
+
+import { containerModeAttribute } from './constants';
+
+export const containerCss = css({
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+
+  [`&${containerModeAttribute.querySelector('dim')}`]: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+  },
+});

--- a/packages/core/sds/src/components/Loader/types.ts
+++ b/packages/core/sds/src/components/Loader/types.ts
@@ -1,0 +1,1 @@
+export type LoaderMode = 'dim' | 'transparent';

--- a/packages/core/sds/src/components/index.ts
+++ b/packages/core/sds/src/components/index.ts
@@ -5,3 +5,4 @@ export * from './TextButton';
 export * from './Badge';
 export * from './SegmentedControl';
 export * from './Accordion';
+export * from './Loader';


### PR DESCRIPTION
## 🎉 변경 사항

### ✔️ Usage

- mode
  - `dim`:  먹은 회색 배경이 깔립니다. (사용처에서 상위에 position: relative 해주게 되면 fit하게 들어갑니다.)
  - `transparent` : 배경 없이 로더만 보입니다.

```tsx
<Loader mode="dim | transparent" />
```

### 🤔 Container는 왜 있나요?

- **풀페이지** 혹은 **일부 컨텐츠 영역 중앙**에 쓰일 목적의 로더라서 w, h 100%로 씌워져 있어요.
- 사용성에 따라 로더 알맹이만 따로 제공할 생각도 있어요.

### 🔥 동작

https://github.com/user-attachments/assets/ec8ad685-dc6d-4c52-89cb-b45735d139c7

## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
