### PR TITLE
feat(sds): Skeleton 컴포넌트 추가

### DIFF
--- a/packages/core/sds/src/components/Skeleton/Paragraphs.tsx
+++ b/packages/core/sds/src/components/Skeleton/Paragraphs.tsx
@@ -1,0 +1,19 @@
+// eslint-disable-next-line import/no-cycle
+import { SkeletonImpl } from './Skeleton';
+import { paragraphsContainer } from './styles';
+
+export interface SkeletonParagraphsProps {
+  count?: number;
+}
+
+export const SkeletonParagraphs = (props: SkeletonParagraphsProps) => {
+  const { count = 3 } = props;
+
+  return (
+    <div css={paragraphsContainer}>
+      {Array.from({ length: count }, (_, index) => (
+        <SkeletonImpl key={index} />
+      ))}
+    </div>
+  );
+};

--- a/packages/core/sds/src/components/Skeleton/Paragraphs.tsx
+++ b/packages/core/sds/src/components/Skeleton/Paragraphs.tsx
@@ -1,19 +1,25 @@
+import { forwardRef, HTMLAttributes } from 'react';
+
 // eslint-disable-next-line import/no-cycle
 import { SkeletonImpl } from './Skeleton';
 import { paragraphsContainer } from './styles';
 
-export interface SkeletonParagraphsProps {
+export interface SkeletonParagraphsProps extends HTMLAttributes<HTMLDivElement> {
   count?: number;
 }
 
-export const SkeletonParagraphs = (props: SkeletonParagraphsProps) => {
-  const { count = 3 } = props;
+export const SkeletonParagraphs = forwardRef<HTMLDivElement, SkeletonParagraphsProps>(
+  (props: SkeletonParagraphsProps) => {
+    const { count = 3 } = props;
 
-  return (
-    <div css={paragraphsContainer}>
-      {Array.from({ length: count }, (_, index) => (
-        <SkeletonImpl key={index} />
-      ))}
-    </div>
-  );
-};
+    return (
+      <div css={paragraphsContainer}>
+        {Array.from({ length: count }, (_, index) => (
+          <SkeletonImpl key={index} />
+        ))}
+      </div>
+    );
+  },
+);
+
+SkeletonParagraphs.displayName = 'SkeletonParagraphs';

--- a/packages/core/sds/src/components/Skeleton/Skeleton.tsx
+++ b/packages/core/sds/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,28 @@
+import { forwardRef, HTMLAttributes } from 'react';
+
+// eslint-disable-next-line import/no-cycle
+import { SkeletonParagraphs } from './Paragraphs';
+import { skeletonCss } from './styles';
+
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  width?: number;
+  height?: number;
+}
+
+export const SkeletonImpl = forwardRef<HTMLDivElement, SkeletonProps>((props, ref) => {
+  const { width, height, style: styleFromProps, ...restProps } = props;
+
+  const style = {
+    width: width,
+    height: height,
+    ...styleFromProps,
+  };
+
+  return <div ref={ref} style={style} css={skeletonCss} {...restProps} />;
+});
+
+SkeletonImpl.displayName = 'Skeleton';
+
+export const Skeleton = Object.assign(SkeletonImpl, {
+  Paragraphs: SkeletonParagraphs,
+});

--- a/packages/core/sds/src/components/Skeleton/index.ts
+++ b/packages/core/sds/src/components/Skeleton/index.ts
@@ -1,0 +1,4 @@
+export { Skeleton } from './Skeleton';
+export type { SkeletonProps } from './Skeleton';
+
+export type { SkeletonParagraphs } from './Paragraphs';

--- a/packages/core/sds/src/components/Skeleton/styles.ts
+++ b/packages/core/sds/src/components/Skeleton/styles.ts
@@ -1,0 +1,48 @@
+import { css, keyframes } from '@emotion/react';
+
+import { borderRadiusVariants, size } from '@sds/theme';
+
+const waveAnimation = keyframes`
+  0% {
+    background-position: -200px 0; 
+  }
+  100% {
+    background-position: 200px 0; 
+  }
+`;
+
+export const skeletonCss = css({
+  width: '100%',
+  height: '100%',
+  borderRadius: borderRadiusVariants.small,
+  background: 'linear-gradient(120deg, #fafafa 25%, #F4F4F4 50%, #fafafa 75%)',
+  animation: `${waveAnimation} 4s infinite linear`,
+});
+
+export const paragraphsContainer = css({
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+
+  '& > div': {
+    // NOTE: base typography인 body3의 line-height의 높이로 설정
+    height: '14px',
+  },
+
+  '& div + div': {
+    marginTop: size['6xs'],
+  },
+
+  '& > div:nth-child(3n + 1)': {
+    width: '80%',
+  },
+
+  '& > div:nth-child(3n + 2)': {
+    width: '40%',
+  },
+
+  '& > div:nth-child(3n)': {
+    width: '55%',
+  },
+});

--- a/packages/core/sds/src/components/index.ts
+++ b/packages/core/sds/src/components/index.ts
@@ -6,3 +6,4 @@ export * from './Badge';
 export * from './SegmentedControl';
 export * from './Accordion';
 export * from './Loader';
+export * from './Skeleton';


### PR DESCRIPTION
## 🎉 변경 사항

- `Skeleton` 컴포넌트를 추가합니다.

### ✔️ Usage

```tsx
// 기본적으로 100%입니다.
<Skeleton width?={number} height?={number} />

// 기본적으로 count = 3 입니다.
<Skeleton.Paragraphs count?={number} />
```

### 🤔 Skeleton.Paragraphs 는 무엇인가요?

- 텍스트를 불러올 자리에 사용하기 편하도록 추가했어요.
- `count`라는 prop을 통해 더 많은 줄을 표시할 수 있어요.

### ✔️ 동작

https://github.com/user-attachments/assets/4eb4f0a1-b9a0-4ef7-ab34-94a189c37d84




## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
