### PR TITLE
fix(sds): Skeleton.Paragraphs 누락된 ref 추가 및 타입 수정

### DIFF
--- a/packages/core/sds/src/components/Skeleton/Paragraphs.tsx
+++ b/packages/core/sds/src/components/Skeleton/Paragraphs.tsx
@@ -8,18 +8,16 @@ export interface SkeletonParagraphsProps extends HTMLAttributes<HTMLDivElement> 
   count?: number;
 }
 
-export const SkeletonParagraphs = forwardRef<HTMLDivElement, SkeletonParagraphsProps>(
-  (props: SkeletonParagraphsProps) => {
-    const { count = 3 } = props;
+export const SkeletonParagraphs = forwardRef<HTMLDivElement, SkeletonParagraphsProps>((props, ref) => {
+  const { count = 3 } = props;
 
-    return (
-      <div css={paragraphsContainer}>
-        {Array.from({ length: count }, (_, index) => (
-          <SkeletonImpl key={index} />
-        ))}
-      </div>
-    );
-  },
-);
+  return (
+    <div css={paragraphsContainer} ref={ref}>
+      {Array.from({ length: count }, (_, index) => (
+        <SkeletonImpl key={index} />
+      ))}
+    </div>
+  );
+});
 
 SkeletonParagraphs.displayName = 'SkeletonParagraphs';

--- a/packages/core/sds/src/components/Skeleton/Paragraphs.tsx
+++ b/packages/core/sds/src/components/Skeleton/Paragraphs.tsx
@@ -9,10 +9,10 @@ export interface SkeletonParagraphsProps extends HTMLAttributes<HTMLDivElement> 
 }
 
 export const SkeletonParagraphs = forwardRef<HTMLDivElement, SkeletonParagraphsProps>((props, ref) => {
-  const { count = 3 } = props;
+  const { count = 3, ...restProps } = props;
 
   return (
-    <div css={paragraphsContainer} ref={ref}>
+    <div css={paragraphsContainer} ref={ref} {...restProps}>
       {Array.from({ length: count }, (_, index) => (
         <SkeletonImpl key={index} />
       ))}


### PR DESCRIPTION
## 🎉 변경 사항
스켈레톤 Paragraphs 에 ref가 누락되어있고, 타입이 중복으로 참조되어서 제거했습니다.


<img width="1017" alt="스크린샷 2024-08-18 오전 11 20 18" src="https://github.com/user-attachments/assets/3cec0503-d2b0-45ef-b1ed-11d12d336c87">



## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
