### PR TITLE
fix(web-domains): 다음 질문인 카카오톡 공유하기 오지정 오류 해결

### DIFF
--- a/packages/web-domains/src/relay-question/features/share-group/types/index.ts
+++ b/packages/web-domains/src/relay-question/features/share-group/types/index.ts
@@ -1,3 +1,10 @@
+interface TargetMember {
+  meetingMemberId: number;
+  name: string;
+  profileImageFileUrl: string;
+  role: string;
+}
+
 export interface ActiveQuestionResponse {
   meetingQuestionId: number;
   questionImageFileUrl: string;
@@ -9,10 +16,6 @@ export interface ActiveQuestionResponse {
   startTime: string;
   isAnswered: boolean;
   isQuestionRegistered: boolean;
-  targetMember: {
-    meetingMemberId: number;
-    name: string;
-    profileImageFileUrl: string;
-    role: string;
-  };
+  targetMember: TargetMember;
+  nextTargetMember: TargetMember;
 }

--- a/packages/web-domains/src/relay-question/features/share-next-questioner/containers/ShareNextQuestionerContainer/ShareNextQuestionerContainer.tsx
+++ b/packages/web-domains/src/relay-question/features/share-next-questioner/containers/ShareNextQuestionerContainer/ShareNextQuestionerContainer.tsx
@@ -66,7 +66,7 @@ export const ShareNextQuestionerContainer = () => {
         topTitle="다음 릴레이 질문인에게"
         bottomTitle="공유해 보세요!"
         shareImageUrl={KAKAO_IMAGE_URL}
-        shareDescription={`다음 질문인은 ${activeQuestion?.targetMember.name}님이에요! 현재 진행 중인 릴레이 질문이 끝나면 질문을 꼭! 생성해주세요`}
+        shareDescription={`다음 질문인은 ${activeQuestion?.nextTargetMember?.name || '000'}님이에요! 현재 진행 중인 릴레이 질문이 끝나면 질문을 꼭! 생성해주세요`}
         shareLink={`${getWebDomain()}/answer/opening`}
       />
     </>

--- a/packages/web-domains/src/relay-question/features/share-next-questioner/containers/ShareNextQuestionerContainer/ShareNextQuestionerContainer.tsx
+++ b/packages/web-domains/src/relay-question/features/share-next-questioner/containers/ShareNextQuestionerContainer/ShareNextQuestionerContainer.tsx
@@ -54,7 +54,9 @@ export const ShareNextQuestionerContainer = () => {
               다음 질문인에게 공유하기
             </Button>
             <Link href="/answer/opening">
-              <Button variant="sub">제일 먼저 답변하기</Button>
+              <Button variant="sub" size="large">
+                제일 먼저 답변하기
+              </Button>
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## 🎉 변경 사항

* 다음 질문인에게 공유하기 페이지에서 카카오톡 공유하기 모달 기능을 사용했을 때, 다음 질문인이 아닌 현재 질문인이 표시되는 오류 수정
* 다음 질문인에게 공유하기 페이지에서 하단 버튼 size 오지정 스타일 오류 해결

## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
