### PR TITLE
fix(sds): Txt, TextButton 컴포넌트 기본 스타일은 스타일 오버라이드 시 우선순위가 높이 올라오지 않도록 css 처리

### DIFF
--- a/packages/core/sds/src/components/TextButton/TextButton.tsx
+++ b/packages/core/sds/src/components/TextButton/TextButton.tsx
@@ -4,7 +4,7 @@ import { colors } from '@sds/theme';
 
 import { Icon } from '../Icon';
 
-import { arrowIconCss, textButtonCss } from './styles';
+import { arrowIconCss, colorVar, textButtonCss, textDecorationVar } from './styles';
 import { TextButtonVariant } from './types';
 
 export interface TextButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -19,8 +19,8 @@ export const TextButton = forwardRef<HTMLButtonElement, TextButtonProps>((props,
   const isArrowVariant = variant === 'arrow';
 
   const style = {
-    color,
-    ...(isUnderlineVariant && { textDecoration: 'underline' }),
+    [colorVar]: color,
+    [textDecorationVar]: isUnderlineVariant ? 'underline' : 'none',
     ...styleFromProps,
   };
 

--- a/packages/core/sds/src/components/TextButton/styles.ts
+++ b/packages/core/sds/src/components/TextButton/styles.ts
@@ -1,4 +1,8 @@
 import { css } from '@emotion/react';
+import { getCssVar } from '@sambad/css-utils';
+
+export const colorVar = '--sambad-text-button-color';
+export const textDecorationVar = '--sambad-text-button-text-decoration';
 
 export const textButtonCss = css({
   display: 'inline-flex',
@@ -7,6 +11,8 @@ export const textButtonCss = css({
   cursor: 'pointer',
   fontSize: '12px',
   lineHeight: '150%',
+  color: getCssVar(colorVar),
+  textDecoration: getCssVar(textDecorationVar),
 
   '&:disabled': {
     cursor: 'not-allowed',

--- a/packages/core/sds/src/components/Typography/Txt.tsx
+++ b/packages/core/sds/src/components/Typography/Txt.tsx
@@ -2,7 +2,15 @@ import { ElementType, forwardRef, HTMLAttributes } from 'react';
 
 import { colors } from '@sds/theme';
 
-import { fontSizeByTypography, fontWeightByTypography, fontWeightVariants } from './styles';
+import {
+  colorVar,
+  fontSizeByTypography,
+  fontSizeVar,
+  fontWeightByTypography,
+  fontWeightVar,
+  fontWeightVariants,
+  TxtCss,
+} from './styles';
 import { FontWeight, Typography } from './types';
 
 /**
@@ -31,14 +39,13 @@ export const Txt = forwardRef<HTMLSpanElement, TxtProps>((props, ref) => {
   const fontSize = fontSizeByTypography[typography];
 
   const style = {
-    color,
-    fontWeight,
-    fontSize,
-    lineHeight: '150%',
+    [colorVar]: color,
+    [fontWeightVar]: fontWeight,
+    [fontSizeVar]: fontSize,
     ...styleFromProps,
   };
 
-  return <Tag ref={ref} style={style} {...restProps} />;
+  return <Tag ref={ref} css={TxtCss} style={style} {...restProps} />;
 });
 
 Txt.displayName = 'Txt';

--- a/packages/core/sds/src/components/Typography/styles.ts
+++ b/packages/core/sds/src/components/Typography/styles.ts
@@ -1,4 +1,11 @@
+import { css } from '@emotion/react';
+import { getCssVar } from '@sambad/css-utils';
+
 import { FontWeight, Typography } from './types';
+
+export const colorVar = '--sambad-typography-color';
+export const fontWeightVar = '--sambad-typography-font-weight';
+export const fontSizeVar = '--sambad-typography-font-size';
 
 export const fontWeightVariants: Record<FontWeight, number> = {
   regular: 400,
@@ -40,3 +47,10 @@ export const fontWeightByTypography: Record<Typography, FontWeight> = {
   body4: 'regular',
   body5: 'regular',
 };
+
+export const TxtCss = css({
+  color: getCssVar(colorVar),
+  fontWeight: getCssVar(fontWeightVar),
+  fontSize: getCssVar(fontSizeVar),
+  lineHeight: '150%',
+});


### PR DESCRIPTION
## 🎉 변경 사항

사용처에서 스타일 오버라이드 시 기본 스타일이 우선순위가 더 높아(style로 스타일 주입) 오버라이드 시 불필요한 우선순위를 높여주는 작업을 해야 했습니다. 

이를 css variable과 css prop으로 처리하여 우선순위를 낮춥니다.

## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
