### PR TITLE
fix(relay-question): 그룹 공유 클로징 페이지에서 모임 이름 대신 '삼봤드의 모험' 상수값으로 고정되어 있던 오류 수정

### DIFF
--- a/packages/web-domains/src/relay-question/features/share-group/containers/CurrentRelayQuestionCountContainer/CurrentRelayQuestionCountContainer.tsx
+++ b/packages/web-domains/src/relay-question/features/share-group/containers/CurrentRelayQuestionCountContainer/CurrentRelayQuestionCountContainer.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'next/navigation';
 import { useState } from 'react';
 
 import { KakaoShareModal, getWebDomain } from '@/common';
+import { useGetMeetingInfo } from '@/home/common/apis/queries/useGetMeetingName';
 
 import { ShareGroupBackground } from '../../../../assets/ShareGroupBackground';
 import { ShareGroupCheckIcon } from '../../../../assets/ShareGroupCheckIcon';
@@ -28,12 +29,15 @@ export const CurrentRelayQuestionCountContainer = () => {
   const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
 
   const { activeQuestion } = useActiveQuestionQuery(Number(meetingId));
+  const { data } = useGetMeetingInfo({});
 
   const handleOpenShare = () => {
     setIsOpenModal(true);
   };
 
-  if (!activeQuestion) return;
+  if (!activeQuestion || !data) return;
+
+  const currentMeetingName = data.meetings.find(({ meetingId }) => meetingId === Number(meetingId))?.name;
 
   return (
     <>
@@ -50,7 +54,7 @@ export const CurrentRelayQuestionCountContainer = () => {
               fontWeight="regular"
               style={{ textAlign: 'center', marginTop: size['6xs'] }}
             >
-              친해지고 싶은 삼봤드의 모험 모임원들에게 <br />
+              친해지고 싶은 {currentMeetingName} 모임원들에게 <br />
               질문을 공유해 보세요
             </Txt>
           </div>


### PR DESCRIPTION
## 🎉 변경 사항
![image](https://github.com/user-attachments/assets/3932a970-9778-4559-898e-5fa0b700e1fe)

## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
