### PR TITLE
feat(sds, css-utils): ToopTip 컴포넌트 추가 및 getPadding 유틸 메서드 추가

### DIFF
--- a/packages/core/css-utils/src/getPadding.ts
+++ b/packages/core/css-utils/src/getPadding.ts
@@ -1,0 +1,24 @@
+export const getPadding = (
+  top: string | number,
+  right?: string | number,
+  bottom?: string | number,
+  left?: string | number,
+): string => {
+  // 인자가 하나일 때: 네 방향 모두 같은 값
+  if (right === undefined && bottom === undefined && left === undefined) {
+    return `${top}`;
+  }
+
+  // 인자가 두 개일 때: 상하(top/bottom)는 첫 번째 값, 좌우(left/right)는 두 번째 값
+  if (bottom === undefined && left === undefined) {
+    return `${top} ${right}`;
+  }
+
+  // 인자가 세 개일 때: 상(top)은 첫 번째 값, 좌우(left/right)는 두 번째 값, 하(bottom)는 세 번째 값
+  if (left === undefined) {
+    return `${top} ${right} ${bottom}`;
+  }
+
+  // 인자가 네 개일 때: 상(top), 우(right), 하(bottom), 좌(left)를 각각 적용
+  return `${top} ${right} ${bottom} ${left}`;
+};

--- a/packages/core/css-utils/src/getPadding.ts
+++ b/packages/core/css-utils/src/getPadding.ts
@@ -1,3 +1,5 @@
+const formatValue = (value: string | number): string => (typeof value === 'number' ? `${value}px` : value);
+
 export const getPadding = (
   top: string | number,
   right?: string | number,
@@ -6,19 +8,19 @@ export const getPadding = (
 ): string => {
   // 인자가 하나일 때: 네 방향 모두 같은 값
   if (right === undefined && bottom === undefined && left === undefined) {
-    return `${top}`;
+    return formatValue(top);
   }
 
   // 인자가 두 개일 때: 상하(top/bottom)는 첫 번째 값, 좌우(left/right)는 두 번째 값
   if (bottom === undefined && left === undefined) {
-    return `${top} ${right}`;
+    return `${formatValue(top)} ${formatValue(right!)}`;
   }
 
   // 인자가 세 개일 때: 상(top)은 첫 번째 값, 좌우(left/right)는 두 번째 값, 하(bottom)는 세 번째 값
   if (left === undefined) {
-    return `${top} ${right} ${bottom}`;
+    return `${formatValue(top)} ${formatValue(right!)} ${formatValue(bottom!)}`;
   }
 
   // 인자가 네 개일 때: 상(top), 우(right), 하(bottom), 좌(left)를 각각 적용
-  return `${top} ${right} ${bottom} ${left}`;
+  return `${formatValue(top)} ${formatValue(right!)} ${formatValue(bottom!)} ${formatValue(left!)}`;
 };

--- a/packages/core/css-utils/src/index.ts
+++ b/packages/core/css-utils/src/index.ts
@@ -1,2 +1,3 @@
 export { getBorder } from './getBorder';
 export { getCssVar } from './getCssVar';
+export { getPadding } from './getPadding';

--- a/packages/core/sds/src/components/Button/styles.ts
+++ b/packages/core/sds/src/components/Button/styles.ts
@@ -69,6 +69,8 @@ export const buttonCss = css({
   width: '100%',
   height: `var(${buttonHeightVar})`,
   transition: 'background-color 0.3s ease',
+  paddingLeft: size['3xs'],
+  paddingRight: size['3xs'],
 
   display: 'flex',
   justifyContent: 'center',

--- a/packages/core/sds/src/components/ToolTip/ToolTip.tsx
+++ b/packages/core/sds/src/components/ToolTip/ToolTip.tsx
@@ -1,0 +1,38 @@
+import { forwardRef, HTMLAttributes } from 'react';
+
+import { colors } from '@sds/theme';
+
+import { Txt } from '../Typography';
+
+import { animateVariants, arrowCss, tooltipCss } from './styles';
+
+export interface ToolTipProps extends HTMLAttributes<HTMLSpanElement> {
+  reduceAnimate?: boolean;
+}
+
+export const ToolTip = forwardRef<HTMLSpanElement, ToolTipProps>((props, ref) => {
+  const { children, reduceAnimate = false, style: styleFromProps, ...restProps } = props;
+
+  const style = {
+    ...animateVariants[reduceAnimate ? 'none' : 'active'],
+    ...styleFromProps,
+  };
+
+  return (
+    <span ref={ref} style={style} {...restProps}>
+      <span css={tooltipCss}>
+        <Txt typography="title3" color={colors.white}>
+          {children}
+        </Txt>
+        <svg xmlns="http://www.w3.org/2000/svg" width="21" height="18" viewBox="0 0 21 18" fill="none" css={arrowCss}>
+          <path
+            d="M13.8387 15.9401C12.2577 18.3361 8.74228 18.3361 7.1613 15.9401L0.736494 6.20297C-1.01827 3.54354 0.889009 0 4.07519 0H16.9248C20.111 0 22.0183 3.54354 20.2635 6.20297L13.8387 15.9401Z"
+            fill={colors.primary500}
+          />
+        </svg>
+      </span>
+    </span>
+  );
+});
+
+ToolTip.displayName = 'ToolTip';

--- a/packages/core/sds/src/components/ToolTip/ToolTip.tsx
+++ b/packages/core/sds/src/components/ToolTip/ToolTip.tsx
@@ -1,26 +1,25 @@
-import { forwardRef, HTMLAttributes } from 'react';
+import { CSSProperties, forwardRef, HTMLAttributes } from 'react';
 
 import { colors } from '@sds/theme';
 
 import { Txt } from '../Typography';
 
-import { animateVariants, arrowCss, tooltipCss } from './styles';
+import { arrowCss, tooltipCss } from './styles';
 
 export interface ToolTipProps extends HTMLAttributes<HTMLSpanElement> {
   reduceAnimate?: boolean;
 }
 
 export const ToolTip = forwardRef<HTMLSpanElement, ToolTipProps>((props, ref) => {
-  const { children, reduceAnimate = false, style: styleFromProps, ...restProps } = props;
+  const { children, reduceAnimate = false, ...restProps } = props;
 
-  const style = {
-    ...animateVariants[reduceAnimate ? 'none' : 'active'],
-    ...styleFromProps,
+  const toolTipStyle: CSSProperties = {
+    ...(reduceAnimate && { animation: 'none' }),
   };
 
   return (
-    <span ref={ref} style={style} {...restProps}>
-      <span css={tooltipCss}>
+    <span ref={ref} {...restProps}>
+      <span css={tooltipCss} style={toolTipStyle}>
         <Txt typography="title3" color={colors.white}>
           {children}
         </Txt>

--- a/packages/core/sds/src/components/ToolTip/index.ts
+++ b/packages/core/sds/src/components/ToolTip/index.ts
@@ -1,0 +1,2 @@
+export { ToolTip } from './ToolTip';
+export type { ToolTipProps } from './ToolTip';

--- a/packages/core/sds/src/components/ToolTip/styles.ts
+++ b/packages/core/sds/src/components/ToolTip/styles.ts
@@ -1,0 +1,41 @@
+import { css, keyframes } from '@emotion/react';
+import { getCssVar, getPadding } from '@sambad/css-utils';
+
+import { borderRadiusVariants, colors, size } from '@sds/theme';
+
+const bounceAnimation = keyframes`
+   to{
+        transform: translateY(-12px);
+    }
+`;
+
+const animateVar = '--sambad-tooltip-animate';
+
+interface AnimateVariants {
+  [animateVar]: string;
+}
+
+export const animateVariants: Record<'none' | 'active', AnimateVariants> = {
+  none: {
+    [animateVar]: 'none',
+  },
+  active: {
+    [animateVar]: `${bounceAnimation} 0.8s cubic-bezier(0, 0, 0.5, 0.99) infinite alternate`,
+  },
+};
+
+export const tooltipCss = css({
+  position: 'relative',
+  borderRadius: borderRadiusVariants.medium,
+  backgroundColor: colors.primary500,
+  padding: getPadding(size['5xs'], size['4xs']),
+  display: 'inline-flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  animation: getCssVar(animateVar),
+});
+
+export const arrowCss = css({
+  position: 'absolute',
+  bottom: -12,
+});

--- a/packages/core/sds/src/components/ToolTip/styles.ts
+++ b/packages/core/sds/src/components/ToolTip/styles.ts
@@ -1,5 +1,5 @@
 import { css, keyframes } from '@emotion/react';
-import { getCssVar, getPadding } from '@sambad/css-utils';
+import { getPadding } from '@sambad/css-utils';
 
 import { borderRadiusVariants, colors, size } from '@sds/theme';
 
@@ -9,21 +9,6 @@ const bounceAnimation = keyframes`
     }
 `;
 
-const animateVar = '--sambad-tooltip-animate';
-
-interface AnimateVariants {
-  [animateVar]: string;
-}
-
-export const animateVariants: Record<'none' | 'active', AnimateVariants> = {
-  none: {
-    [animateVar]: 'none',
-  },
-  active: {
-    [animateVar]: `${bounceAnimation} 0.8s cubic-bezier(0, 0, 0.5, 0.99) infinite alternate`,
-  },
-};
-
 export const tooltipCss = css({
   position: 'relative',
   borderRadius: borderRadiusVariants.medium,
@@ -32,7 +17,7 @@ export const tooltipCss = css({
   display: 'inline-flex',
   justifyContent: 'center',
   alignItems: 'center',
-  animation: getCssVar(animateVar),
+  animation: `${bounceAnimation} 0.8s cubic-bezier(0, 0, 0.5, 0.99) infinite alternate`,
 });
 
 export const arrowCss = css({

--- a/packages/core/sds/src/components/index.ts
+++ b/packages/core/sds/src/components/index.ts
@@ -9,3 +9,4 @@ export * from './Skeleton';
 export * from './Spinner';
 export * from './TextButton';
 export * from './Typography';
+export * from './ToolTip';


### PR DESCRIPTION
## 🎉 변경 사항

### ✔️ Usage

```tsx
<ToolTip>툴팁내용</ToolTip>
```

https://github.com/user-attachments/assets/9397b91e-e09e-4476-a353-6c0d4b40ff9c



### ✔️ 애니메이션 기본 적용

애니메이션이 기본적으로 적용되어 있어요. 애니메이션을 끄고 싶다면 `reduceAnimate={true}`를 사용해주세요.

### 📝 TODO

`direction`이라는 인터페이스를 추가할 예정이에요.

## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
