### PR TITLE
fix(web-domains): 모임장/원 취미 정보 입력 페이지 디자인 정의서 업데이트

### DIFF
--- a/packages/web-domains/src/user/features/get-user-info/components/Form/HobbiesInfoForm.tsx
+++ b/packages/web-domains/src/user/features/get-user-info/components/Form/HobbiesInfoForm.tsx
@@ -47,11 +47,8 @@ export const HobbiesInfoForm = ({ hobbyList }: HobbiesFormProps) => {
         <Controller
           name="hobbyIds"
           control={control}
-          rules={{
-            validate: (value) => value.length <= 3 || '최대 3개까지 선택할 수 있습니다',
-          }}
           render={({ field: { value, onChange } }) => (
-            <CheckboxGroup value={value} onValueChange={onChange} maxLength={3}>
+            <CheckboxGroup value={value} onValueChange={onChange}>
               {hobbyList?.map(({ hobbyId, content }) => (
                 <CheckboxGroup.Item
                   key={hobbyId}

--- a/packages/web-domains/src/user/features/get-user-info/containers/GetUserHobbiesContainer.tsx
+++ b/packages/web-domains/src/user/features/get-user-info/containers/GetUserHobbiesContainer.tsx
@@ -6,7 +6,7 @@ export const GetUserHobbiesContainer = () => {
 
   return (
     <>
-      <FormTitle title="취미를 최대" subTitle="세 개 까지만 선택해주세요" style={{ paddingTop: '28px' }} />
+      <FormTitle title="즐기는 취미를" subTitle="자유롭게 선택해주세요" style={{ paddingTop: '28px' }} />
       <HobbiesInfoForm hobbyList={hobbyList} />
     </>
   );


### PR DESCRIPTION
## 🎉 변경 사항
기존에 최대 3개 선택 가능에서 개수 제한 없이 선택 가능으로 변경 

## 🔗 링크
[피그마](https://www.figma.com/design/K0vbFsWUNzQXl5NRGra2m9/%5BDPM%5D-3%ED%8C%80%F0%9F%A7%91%E2%80%8D%F0%9F%9A%80?node-id=2239-23270&t=sm07N3wSJLt2zw5N-4)

#### 🙏 여기는 꼭 봐주세요!
