### PR TITLE
fix(web-domains): EmptyView 아이콘 색 변경

### DIFF
--- a/packages/web-domains/src/common/components/EmptyView/EmptyView.tsx
+++ b/packages/web-domains/src/common/components/EmptyView/EmptyView.tsx
@@ -21,7 +21,7 @@ export const EmptyView = (props: EmptyViewProps) => {
 
   return (
     <div style={style} {...restProps}>
-      <Icon name="sad-user" size={40} color={colors.grey600} style={{ paddingBottom: size['5xs'] }} />
+      <Icon name="sad-user" size={40} color={colors.grey400} style={{ paddingBottom: size['5xs'] }} />
       <Txt typography="title3" color={colors.grey600}>
         {title}
       </Txt>


### PR DESCRIPTION
## 🎉 변경 사항
아이콘 색 grey600에서 grey400으로 변경하였습니다.

| as-is | to-be |
|:--:|:--:|
|![Simulator Screen Shot - iPhone 12 mini - 2024-09-12 at 02 41 48](https://github.com/user-attachments/assets/27538fcc-6d22-47b5-a766-fea6c584c0c4)|![Simulator Screen Shot - iPhone 12 mini - 2024-09-12 at 02 40 41](https://github.com/user-attachments/assets/8d5eca39-d9ba-48e2-9939-fbef636605b0)|

## 🔗 링크
[SAMBAD-QA1-76](https://www.notion.so/depromeet/5bfd181d0fe8473fb88d47bd97fb2d69?pvs=4)

#### 🙏 여기는 꼭 봐주세요!
