### PR TITLE
fix(sds, web-domains, web): sds에서 절대경로 alias를 걷어내고, 이로인해 혼재되어 사용되고 있던 import 경로를 정리합니다 

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -8,8 +8,7 @@
     ],
     "baseUrl": "../../packages",
     "paths": {
-      "@/*": ["./web-domains/src/*"],
-      "@sds/*": ["./core/sds/src/*"]
+      "@/*": ["./web-domains/src/*"]
     }
   },
   "include": ["next-env.d.ts", "next.config.js", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -12,15 +12,6 @@
       "@sds/*": ["./core/sds/src/*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "next.config.js",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    "../../packages/web-domains/src/common/styles/GlobalStyles.tsx",
-    "../../packages/web-domains/src/common/layout/RootLayout.styles.ts",
-    "../../packages/web-domains/src/common/layout/RootLayout.tsx"
-  ],
+  "include": ["next-env.d.ts", "next.config.js", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/core/css-utils/tsconfig.json
+++ b/packages/core/css-utils/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src", "../../apps/web/layout/RootLayout.styles.ts", "../../apps/web/layout/RootLayout.tsx"],
+  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/core/react-utils/tsconfig.json
+++ b/packages/core/react-utils/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "@sambad/typescript-config/react-library.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "paths": {
-      "@sds/*": ["./src/*"]
-    }
+    "outDir": "dist"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/core/sds/src/components/Accordion/Accordion.tsx
+++ b/packages/core/sds/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, HTMLAttributes, useCallback } from 'react';
 
-import { useControllableState } from '@sds/hooks';
+import { useControllableState } from '../../hooks';
 
 import { AccordionContent } from './Content';
 import { AccordionProvider } from './context';

--- a/packages/core/sds/src/components/Accordion/Trigger.tsx
+++ b/packages/core/sds/src/components/Accordion/Trigger.tsx
@@ -1,8 +1,7 @@
 import { forwardRef, HTMLAttributes } from 'react';
 
-import { colors } from '@sds/theme';
-import { composeEventHandlers } from '@sds/utils';
-
+import { colors } from '../../theme';
+import { composeEventHandlers } from '../../utils';
 import { Icon } from '../Icon';
 
 import { arrowIconAttribute } from './constants';

--- a/packages/core/sds/src/components/Accordion/context.ts
+++ b/packages/core/sds/src/components/Accordion/context.ts
@@ -1,4 +1,4 @@
-import { buildContext } from '@sds/utils';
+import { buildContext } from '../../utils';
 
 interface Context {
   value?: Array<string>;

--- a/packages/core/sds/src/components/Accordion/styles.ts
+++ b/packages/core/sds/src/components/Accordion/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import { size } from '@sds/theme';
+import { size } from '../../theme';
 
 import { accordionItemStateAttribute, arrowIconAttribute, contentAttribute } from './constants';
 

--- a/packages/core/sds/src/components/Badge/Badge.tsx
+++ b/packages/core/sds/src/components/Badge/Badge.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, HTMLAttributes } from 'react';
 
-import { colors } from '@sds/theme';
+import { colors } from '../../theme';
 
 import { badgeCss } from './styles';
 

--- a/packages/core/sds/src/components/Badge/styles.ts
+++ b/packages/core/sds/src/components/Badge/styles.ts
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 
-import { borderRadiusVariants, size } from '@sds/theme';
-
+import { borderRadiusVariants, size } from '../../theme';
 import { fontWeightVariants } from '../Typography/styles';
 
 export const badgeCss = css({

--- a/packages/core/sds/src/components/Button/styles.ts
+++ b/packages/core/sds/src/components/Button/styles.ts
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 
-import { borderRadiusVariants, colors, size } from '@sds/theme';
-
+import { borderRadiusVariants, colors, size } from '../../theme';
 import { fontWeightVariants } from '../Typography';
 
 import { ButtonSize, ButtonVariant } from './types';

--- a/packages/core/sds/src/components/Checkbox/Checkbox.tsx
+++ b/packages/core/sds/src/components/Checkbox/Checkbox.tsx
@@ -1,10 +1,9 @@
 import { useId } from '@sambad/react-utils';
 import { CSSProperties, forwardRef, InputHTMLAttributes, ReactNode } from 'react';
 
-import { useControllableState } from '@sds/hooks';
-import { colors } from '@sds/theme';
-import { composeEventHandlers } from '@sds/utils';
-
+import { useControllableState } from '../../hooks';
+import { colors } from '../../theme';
+import { composeEventHandlers } from '../../utils';
 import { Icon } from '../Icon';
 import { Txt } from '../Typography';
 

--- a/packages/core/sds/src/components/Checkbox/styles.ts
+++ b/packages/core/sds/src/components/Checkbox/styles.ts
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { getCssVar } from '@sambad/css-utils';
 import { CSSProperties } from 'react';
 
-import { colors, size } from '@sds/theme';
+import { colors, size } from '../../theme';
 
 const inputBackgroundColorVar = '--sambad-checkbox-input-background-color';
 const inputBoxShadowVar = '--sambad-checkbox-input-box-shadow';

--- a/packages/core/sds/src/components/Icon/Icon.tsx
+++ b/packages/core/sds/src/components/Icon/Icon.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, HTMLAttributes } from 'react';
 
-import { colors } from '@sds/theme';
+import { colors } from '../../theme';
 
 import { iconMap } from './constants';
 import { IconAssetProps } from './types';

--- a/packages/core/sds/src/components/Icon/index.ts
+++ b/packages/core/sds/src/components/Icon/index.ts
@@ -1,2 +1,3 @@
 export { Icon } from './Icon';
 export type { IconProps } from './Icon';
+export type { IconAssetProps } from './types';

--- a/packages/core/sds/src/components/SegmentedControl/Item.tsx
+++ b/packages/core/sds/src/components/SegmentedControl/Item.tsx
@@ -1,9 +1,8 @@
 import { Item as RadixToggleItem, ToggleGroupItemProps } from '@radix-ui/react-toggle-group';
 import { forwardRef, useRef } from 'react';
 
-import { useComposedRefs, useResizeObserver } from '@sds/hooks';
-import { composeEventHandlers } from '@sds/utils';
-
+import { useComposedRefs, useResizeObserver } from '../../hooks';
+import { composeEventHandlers } from '../../utils';
 import { Txt } from '../Typography';
 
 import { useSegmentedControlContext } from './context';

--- a/packages/core/sds/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/core/sds/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,7 +1,7 @@
 import { Root as RadixToggleRoot, ToggleGroupSingleProps } from '@radix-ui/react-toggle-group';
 import { forwardRef, useState } from 'react';
 
-import { useControllableState } from '@sds/hooks';
+import { useControllableState } from '../../hooks';
 
 import { indicatorAttribute } from './constants';
 import { SegmentedControlProvider } from './context';

--- a/packages/core/sds/src/components/SegmentedControl/context.ts
+++ b/packages/core/sds/src/components/SegmentedControl/context.ts
@@ -1,4 +1,4 @@
-import { buildContext } from '@sds/utils';
+import { buildContext } from '../../utils';
 
 interface Context {
   value?: string;

--- a/packages/core/sds/src/components/SegmentedControl/styles.ts
+++ b/packages/core/sds/src/components/SegmentedControl/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import { borderRadiusVariants, colors, size } from '@sds/theme';
+import { borderRadiusVariants, colors, size } from '../../theme';
 
 import { indicatorAttribute } from './constants';
 

--- a/packages/core/sds/src/components/Skeleton/styles.ts
+++ b/packages/core/sds/src/components/Skeleton/styles.ts
@@ -1,6 +1,6 @@
 import { css, keyframes } from '@emotion/react';
 
-import { borderRadiusVariants, size } from '@sds/theme';
+import { borderRadiusVariants, size } from '../../theme';
 
 const waveAnimation = keyframes`
   0% {

--- a/packages/core/sds/src/components/TextButton/TextButton.tsx
+++ b/packages/core/sds/src/components/TextButton/TextButton.tsx
@@ -1,7 +1,6 @@
 import { ButtonHTMLAttributes, forwardRef } from 'react';
 
-import { colors } from '@sds/theme';
-
+import { colors } from '../../theme';
 import { Icon } from '../Icon';
 
 import { arrowIconCss, colorVar, textButtonCss, textDecorationVar } from './styles';

--- a/packages/core/sds/src/components/ToolTip/ToolTip.tsx
+++ b/packages/core/sds/src/components/ToolTip/ToolTip.tsx
@@ -1,7 +1,6 @@
 import { CSSProperties, forwardRef, HTMLAttributes } from 'react';
 
-import { colors } from '@sds/theme';
-
+import { colors } from '../../theme';
 import { Txt } from '../Typography';
 
 import { arrowCss, tooltipCss } from './styles';

--- a/packages/core/sds/src/components/ToolTip/styles.ts
+++ b/packages/core/sds/src/components/ToolTip/styles.ts
@@ -1,7 +1,7 @@
 import { css, keyframes } from '@emotion/react';
 import { getPadding } from '@sambad/css-utils';
 
-import { borderRadiusVariants, colors, size } from '@sds/theme';
+import { borderRadiusVariants, colors, size } from '../../theme';
 
 const bounceAnimation = keyframes`
    to{

--- a/packages/core/sds/src/components/Typography/Txt.tsx
+++ b/packages/core/sds/src/components/Typography/Txt.tsx
@@ -1,6 +1,6 @@
 import { ElementType, forwardRef, HTMLAttributes } from 'react';
 
-import { colors } from '@sds/theme';
+import { colors } from '../../theme';
 
 import {
   colorVar,

--- a/packages/core/sds/tsconfig.json
+++ b/packages/core/sds/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "@sambad/typescript-config/react-library.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "paths": {
-      "@sds/*": ["./src/*"]
-    }
+    "outDir": "dist"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/web-domains/src/about-me/features/components/Loading/AnsweredQuestionContainerSkeletons.tsx
+++ b/packages/web-domains/src/about-me/features/components/Loading/AnsweredQuestionContainerSkeletons.tsx
@@ -1,5 +1,5 @@
-import { Skeleton } from '@sds/components';
-import { size } from '@sds/theme';
+import { Skeleton } from '@sambad/sds/components';
+import { size } from '@sambad/sds/theme';
 
 export const AnsweredQuestionContainerSkeletons = () => {
   return (

--- a/packages/web-domains/src/about-me/features/containers/ProfileContainer.tsx
+++ b/packages/web-domains/src/about-me/features/containers/ProfileContainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { TextButton } from '@sds/components';
-import { size } from '@sds/theme';
+import { TextButton } from '@sambad/sds/components';
+import { size } from '@sambad/sds/theme';
 import Link from 'next/link';
 import { HTMLAttributes } from 'react';
 

--- a/packages/web-domains/src/about-me/features/containers/ScreenContainer.tsx
+++ b/packages/web-domains/src/about-me/features/containers/ScreenContainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { TextButton, Txt } from '@sambad/sds/components';
 import { colors, shadow, size } from '@sambad/sds/theme';
-import { TextButton, Txt } from '@sds/components';
 import { useRouter } from 'next/navigation';
 import { useRef } from 'react';
 

--- a/packages/web-domains/src/answer/common/components/Countdown/AnswerCountdownRender.tsx
+++ b/packages/web-domains/src/answer/common/components/Countdown/AnswerCountdownRender.tsx
@@ -1,5 +1,5 @@
-import { Txt } from '@sds/components';
-import { colors, borderRadiusVariants, shadow } from '@sds/theme';
+import { Txt } from '@sambad/sds/components';
+import { colors, borderRadiusVariants, shadow } from '@sambad/sds/theme';
 
 export const AnswerCountdownRender = ({
   hours,

--- a/packages/web-domains/src/answer/features/floating-button/components/AnswerButton.tsx
+++ b/packages/web-domains/src/answer/features/floating-button/components/AnswerButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Button } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 import { Attributes, HTMLAttributes } from 'react';
 
 interface AnswerButtonProps extends Omit<HTMLAttributes<HTMLButtonElement>, 'onClick'> {

--- a/packages/web-domains/src/answer/features/floating-button/components/CommentButton.tsx
+++ b/packages/web-domains/src/answer/features/floating-button/components/CommentButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Button } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 import { Attributes, HTMLAttributes } from 'react';
 
 interface CommentButtonProps extends Omit<HTMLAttributes<HTMLButtonElement>, 'onClick'> {

--- a/packages/web-domains/src/answer/features/progressing-question/components/Skeleton/ProgressingQuestionContainerSkeleton.tsx
+++ b/packages/web-domains/src/answer/features/progressing-question/components/Skeleton/ProgressingQuestionContainerSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@sds/components';
+import { Skeleton } from '@sambad/sds/components';
 
 export const ProgressingQuestionContainerSkeleton = () => {
   return (

--- a/packages/web-domains/src/common/animates/Confetti.tsx
+++ b/packages/web-domains/src/common/animates/Confetti.tsx
@@ -1,4 +1,4 @@
-import { colors } from '@sds/theme';
+import { colors } from '@sambad/sds/theme';
 import { CSSProperties } from 'react';
 import Fireworks from 'react-canvas-confetti/dist/presets/fireworks';
 

--- a/packages/web-domains/src/common/components/Error/404.tsx
+++ b/packages/web-domains/src/common/components/Error/404.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { css } from '@emotion/react';
-import { Icon, Txt } from '@sds/components';
-import { colors, size } from '@sds/theme';
+import { Icon, Txt } from '@sambad/sds/components';
+import { colors, size } from '@sambad/sds/theme';
 
 import { titleCss } from './styles';
 

--- a/packages/web-domains/src/common/components/Error/500.tsx
+++ b/packages/web-domains/src/common/components/Error/500.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button, Txt } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Button, Txt } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 

--- a/packages/web-domains/src/common/components/Error/styles.ts
+++ b/packages/web-domains/src/common/components/Error/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
-import { fontWeightVariants } from '@sds/components';
-import { colors, size } from '@sds/theme';
+import { fontWeightVariants } from '@sambad/sds/components';
+import { colors, size } from '@sambad/sds/theme';
 
 export const containerCss = css({
   width: '100%',

--- a/packages/web-domains/src/common/components/FloatingButton/FloatingButton.tsx
+++ b/packages/web-domains/src/common/components/FloatingButton/FloatingButton.tsx
@@ -1,5 +1,5 @@
-import { Button, ButtonProps } from '@sds/components';
-import { size } from '@sds/theme';
+import { Button, ButtonProps } from '@sambad/sds/components';
+import { size } from '@sambad/sds/theme';
 import { CSSProperties } from 'react';
 
 interface FloatingButtonProps extends ButtonProps {

--- a/packages/web-domains/src/common/components/KakaoShare/KakaoShareModal.tsx
+++ b/packages/web-domains/src/common/components/KakaoShare/KakaoShareModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button, Txt } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Button, Txt } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 import { HTMLAttributes, useEffect, useState } from 'react';
 
 import { Modal } from '../Modal/Modal';

--- a/packages/web-domains/src/home/common/components/BottomSheet/BottomSheet.styles.ts
+++ b/packages/web-domains/src/home/common/components/BottomSheet/BottomSheet.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { colors } from '@sds/theme';
+import { colors } from '@sambad/sds/theme';
 
 export const BottomSheetContainerCss = css({
   position: 'fixed',

--- a/packages/web-domains/src/home/common/components/BottomSheet/BottomSheet.tsx
+++ b/packages/web-domains/src/home/common/components/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,5 @@
-import { Icon, Txt } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Icon, Txt } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 import { CSSProperties, PropsWithChildren, useEffect, useState } from 'react';
 
 import { BodyScrollLock } from '@/common/utils/bodyScrollLock';

--- a/packages/web-domains/src/home/common/components/Navigation/HomeNavigationTab.tsx
+++ b/packages/web-domains/src/home/common/components/Navigation/HomeNavigationTab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Icon, Txt } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Icon, Txt } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 import Link from 'next/link';
 import { PropsWithChildren } from 'react';
 

--- a/packages/web-domains/src/home/features/floating-button/components/AlreadyProgressingQuestionButtonCountdownRender.tsx
+++ b/packages/web-domains/src/home/features/floating-button/components/AlreadyProgressingQuestionButtonCountdownRender.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Txt } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Txt } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 
 export const AlreadyProgressingQuestionButtonCountdownRender = ({
   hours,

--- a/packages/web-domains/src/home/features/floating-button/components/ProgressingQuestionModalCountdownRender.tsx
+++ b/packages/web-domains/src/home/features/floating-button/components/ProgressingQuestionModalCountdownRender.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Txt } from '@sds/components';
-import { borderRadiusVariants, colors } from '@sds/theme';
+import { Txt } from '@sambad/sds/components';
+import { borderRadiusVariants, colors } from '@sambad/sds/theme';
 
 export const ProgressingQuestionModalCountdownRender = ({
   hours,

--- a/packages/web-domains/src/home/features/gather-member/components/GatherMemberProfile/GatherMemberProfile.tsx
+++ b/packages/web-domains/src/home/features/gather-member/components/GatherMemberProfile/GatherMemberProfile.tsx
@@ -1,5 +1,5 @@
 import { Icon, Txt } from '@sambad/sds/components';
-import { colors } from '@sds/theme';
+import { colors } from '@sambad/sds/theme';
 import Link from 'next/link';
 
 import { Avatar } from '@/common/components/Avatar/Avatar';

--- a/packages/web-domains/src/home/features/gather-member/containers/GatherMemberProfileListContainer.tsx
+++ b/packages/web-domains/src/home/features/gather-member/containers/GatherMemberProfileListContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Icon } from '@sds/components';
+import { Icon } from '@sambad/sds/components';
 
 import { KakaoShareModal } from '@/common';
 

--- a/packages/web-domains/src/home/features/home-navigation/containers/HomeNavigationContainer.tsx
+++ b/packages/web-domains/src/home/features/home-navigation/containers/HomeNavigationContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Icon } from '@sds/components';
+import { Icon } from '@sambad/sds/components';
 import { usePathname } from 'next/navigation';
 
 import { HomeNavigation } from '@/home/common/components/Navigation/HomeNavigationTab';

--- a/packages/web-domains/src/home/features/meeting-choice/components/MeetingChoiceBottomSheet.tsx
+++ b/packages/web-domains/src/home/features/meeting-choice/components/MeetingChoiceBottomSheet.tsx
@@ -1,5 +1,5 @@
-import { Txt, Icon } from '@sds/components';
-import { borderRadiusVariants, colors } from '@sds/theme';
+import { Txt, Icon } from '@sambad/sds/components';
+import { borderRadiusVariants, colors } from '@sambad/sds/theme';
 import Link from 'next/link';
 
 import { MeetingInfoType } from '@/home/common/apis/schema/Meeting.schema';

--- a/packages/web-domains/src/home/features/meeting-intro/containers/MeetingIntroContainer.tsx
+++ b/packages/web-domains/src/home/features/meeting-intro/containers/MeetingIntroContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { colors } from '@sds/theme';
+import { colors } from '@sambad/sds/theme';
 
 import { HomeNavigationConatiner } from '../../home-navigation/containers/HomeNavigationContainer';
 import { MeetingChoiceBottomSheet } from '../../meeting-choice/components/MeetingChoiceBottomSheet';

--- a/packages/web-domains/src/home/features/my-profile/components/AboutMe.tsx
+++ b/packages/web-domains/src/home/features/my-profile/components/AboutMe.tsx
@@ -1,4 +1,4 @@
-import { size } from '@sds/theme/size';
+import { size } from '@sambad/sds/theme';
 
 import { MeetingMemberResponse } from '@/about-me/common/apis/schema/MeetingMemberResponse';
 import { HobbyList, IntroduceBox } from '@/about-me/features/components';

--- a/packages/web-domains/src/home/features/my-profile/components/AnswerQuestions.tsx
+++ b/packages/web-domains/src/home/features/my-profile/components/AnswerQuestions.tsx
@@ -1,6 +1,6 @@
 import { If } from '@sambad/react-utils';
-import { Accordion, Checkbox, Txt } from '@sds/components';
-import { colors, size } from '@sds/theme';
+import { Accordion, Checkbox, Txt } from '@sambad/sds/components';
+import { colors, size } from '@sambad/sds/theme';
 import { useRef, useImperativeHandle, forwardRef } from 'react';
 
 import { useUpdateQuestionsActive } from '@/about-me/common/apis/mutates/useUpdateQuestionsActive';

--- a/packages/web-domains/src/home/features/my-profile/components/MyProfile.tsx
+++ b/packages/web-domains/src/home/features/my-profile/components/MyProfile.tsx
@@ -1,5 +1,5 @@
-import { TextButton } from '@sds/components';
-import { size } from '@sds/theme/size';
+import { TextButton } from '@sambad/sds/components';
+import { size } from '@sambad/sds/theme';
 import Link from 'next/link';
 
 import { MeetingMemberResponse } from '@/about-me/common/apis/schema/MeetingMemberResponse';

--- a/packages/web-domains/src/home/features/my-profile/containers/MyprofileContainer.tsx
+++ b/packages/web-domains/src/home/features/my-profile/containers/MyprofileContainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { colors, size } from '@sambad/sds/theme';
-import { SegmentedControl, TextButton, Txt } from '@sds/components';
+import { SegmentedControl, TextButton, Txt } from '@sambad/sds/components';
 
 import {
   aboutMeSectionCss,

--- a/packages/web-domains/src/home/features/my-profile/containers/MyprofileContainer.tsx
+++ b/packages/web-domains/src/home/features/my-profile/containers/MyprofileContainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { colors, size } from '@sambad/sds/theme';
 import { SegmentedControl, TextButton, Txt } from '@sambad/sds/components';
+import { colors, size } from '@sambad/sds/theme';
 
 import {
   aboutMeSectionCss,

--- a/packages/web-domains/src/home/features/notification/components/NotificationItem.tsx
+++ b/packages/web-domains/src/home/features/notification/components/NotificationItem.tsx
@@ -1,5 +1,5 @@
-import { Txt } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Txt } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 import dayjs from 'dayjs';
 import { ReactNode } from 'react';
 

--- a/packages/web-domains/src/home/features/notification/components/NotificationList.tsx
+++ b/packages/web-domains/src/home/features/notification/components/NotificationList.tsx
@@ -1,4 +1,4 @@
-import { colors } from '@sds/theme';
+import { colors } from '@sambad/sds/theme';
 import { ReactNode } from 'react';
 
 import { EmptyView } from '@/common/components';

--- a/packages/web-domains/src/home/features/notification/containers/AlarmListContainer.tsx
+++ b/packages/web-domains/src/home/features/notification/containers/AlarmListContainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button, Icon, Txt } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Button, Icon, Txt } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 
 import { AlarmEventType } from '@/home/common/apis/schema/Notification.schema';
 

--- a/packages/web-domains/src/home/features/previous-question/components/PreviousQuestion/HomePreviousQuestionItem.tsx
+++ b/packages/web-domains/src/home/features/previous-question/components/PreviousQuestion/HomePreviousQuestionItem.tsx
@@ -1,6 +1,5 @@
-import { Txt } from '@sambad/sds/components';
+import { Icon, Txt } from '@sambad/sds/components';
 import { borderRadiusVariants, colors } from '@sambad/sds/theme';
-import { AngleRightIcon } from '@sds/components/Icon/assets/AngleRight';
 import Link from 'next/link';
 
 import { TopPreviousQuestionType } from '@/home/common/apis/schema/useGetPreviousQuestionListQuery.type';
@@ -59,7 +58,7 @@ export const HomePreviousQuestionItem = ({ meetingId, question }: HomePreviousQu
           </Txt>
         </div>
         <div css={{ marginLeft: '20px' }}>
-          <AngleRightIcon size={16} color={colors.grey600} />
+          <Icon name="angle-right" size={16} color={colors.grey600} />
         </div>
       </Link>
     </li>

--- a/packages/web-domains/src/home/features/previous-question/components/Skeleton/PreviousQuestionListContainerSkeleton.tsx
+++ b/packages/web-domains/src/home/features/previous-question/components/Skeleton/PreviousQuestionListContainerSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@sds/components';
+import { Skeleton } from '@sambad/sds/components';
 
 export const PreviousQuestionListContainerSkeleton = () => {
   return (

--- a/packages/web-domains/src/home/features/progressing-question/components/GatherName/GatherName.tsx
+++ b/packages/web-domains/src/home/features/progressing-question/components/GatherName/GatherName.tsx
@@ -1,5 +1,5 @@
 import { Icon, Skeleton, Txt } from '@sambad/sds/components';
-import { colors } from '@sds/theme';
+import { colors } from '@sambad/sds/theme';
 import { HTMLAttributes } from 'react';
 
 interface GatherNameProps extends HTMLAttributes<HTMLDivElement> {

--- a/packages/web-domains/src/home/features/progressing-question/components/QuestionInfo/InActiveCountdownRender.tsx
+++ b/packages/web-domains/src/home/features/progressing-question/components/QuestionInfo/InActiveCountdownRender.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Txt } from '@sds/components';
-import { borderRadiusVariants, colors } from '@sds/theme';
+import { Txt } from '@sambad/sds/components';
+import { borderRadiusVariants, colors } from '@sambad/sds/theme';
 
 export const InActiveCountdownRender = ({
   hours,

--- a/packages/web-domains/src/home/features/progressing-question/components/QuestionInfo/ProgressingQuestionInfo.tsx
+++ b/packages/web-domains/src/home/features/progressing-question/components/QuestionInfo/ProgressingQuestionInfo.tsx
@@ -1,5 +1,5 @@
 import { Txt } from '@sambad/sds/components';
-import { colors } from '@sds/theme';
+import { colors } from '@sambad/sds/theme';
 import { HTMLAttributes, ReactNode } from 'react';
 
 interface ProgressingQuestionInfoProps extends HTMLAttributes<HTMLDivElement> {

--- a/packages/web-domains/src/new-meeting/features/get-meeting-info/components/Checkbox/CheckboxLabel.tsx
+++ b/packages/web-domains/src/new-meeting/features/get-meeting-info/components/Checkbox/CheckboxLabel.tsx
@@ -1,5 +1,5 @@
-import { Txt } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Txt } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 
 import { itemCss } from './styles';
 

--- a/packages/web-domains/src/onboarding/common/assets/icons/QuestionIcon.tsx
+++ b/packages/web-domains/src/onboarding/common/assets/icons/QuestionIcon.tsx
@@ -1,5 +1,5 @@
-import { IconAssetProps } from '@sds/components/Icon/types';
-import { colors } from '@sds/theme';
+import { IconAssetProps } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 
 export const QuestionIcon = (props: IconAssetProps) => {
   const { color = colors.primary500 } = props;

--- a/packages/web-domains/src/onboarding/features/components/Button/NextButton.tsx
+++ b/packages/web-domains/src/onboarding/features/components/Button/NextButton.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@sds/components';
+import { Button } from '@sambad/sds/components';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { StepType, STEPS } from '@/onboarding/common/constants/steps';

--- a/packages/web-domains/src/onboarding/features/components/Button/StartButton.tsx
+++ b/packages/web-domains/src/onboarding/features/components/Button/StartButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from '@sds/components';
+import { Button } from '@sambad/sds/components';
 import { useRouter } from 'next/navigation';
 
 import { useOnBoardingCompleteMutation } from '@/onboarding/common/apis/mutations/useOnBoardingMutation';

--- a/packages/web-domains/src/onboarding/features/components/Button/styles.ts
+++ b/packages/web-domains/src/onboarding/features/components/Button/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { size } from '@sds/theme';
+import { size } from '@sambad/sds/theme';
 
 export const onBoardingButtonCss = css({
   paddingLeft: size['4xl'],

--- a/packages/web-domains/src/onboarding/features/components/Header/Header.tsx
+++ b/packages/web-domains/src/onboarding/features/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Txt } from '@sds/components';
-import { colors, size } from '@sds/theme';
+import { Txt } from '@sambad/sds/components';
+import { colors, size } from '@sambad/sds/theme';
 import { ReactNode } from 'react';
 
 import { textWithSlideUpAnimationCss } from './styles';

--- a/packages/web-domains/src/onboarding/features/components/Layout/OnBoardingLayout.tsx
+++ b/packages/web-domains/src/onboarding/features/components/Layout/OnBoardingLayout.tsx
@@ -1,4 +1,4 @@
-import { colors } from '@sds/theme';
+import { colors } from '@sambad/sds/theme';
 import { CSSProperties, PropsWithChildren } from 'react';
 
 import { STEPS, StepType } from '@/onboarding/common/constants/steps';

--- a/packages/web-domains/src/onboarding/features/components/ProgressIndicator/index.tsx
+++ b/packages/web-domains/src/onboarding/features/components/ProgressIndicator/index.tsx
@@ -1,4 +1,4 @@
-import { colors } from '@sds/theme';
+import { colors } from '@sambad/sds/theme';
 import { HTMLAttributes, PropsWithChildren, forwardRef } from 'react';
 
 import { progressIndicatorCss, stepCss } from './styles';

--- a/packages/web-domains/src/onboarding/features/containers/OnBoardingContainer/onBoardingResultContainer.tsx
+++ b/packages/web-domains/src/onboarding/features/containers/OnBoardingContainer/onBoardingResultContainer.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { colors } from '@sds/theme';
+import { colors } from '@sambad/sds/theme';
 import { Fragment } from 'react/jsx-runtime';
 
 import { QuestionIcon } from '@/onboarding/common/assets/icons/QuestionIcon';

--- a/packages/web-domains/src/onboarding/features/containers/ProgressIndicatorContainer/ProgressIndicatorContainer.tsx
+++ b/packages/web-domains/src/onboarding/features/containers/ProgressIndicatorContainer/ProgressIndicatorContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { size } from '@sds/theme';
+import { size } from '@sambad/sds/theme';
 
 import { STEPS, StepType } from '@/onboarding/common/constants/steps';
 

--- a/packages/web-domains/src/relay-question/features/select-relay-question/components/Questioner/Questioner.tsx
+++ b/packages/web-domains/src/relay-question/features/select-relay-question/components/Questioner/Questioner.tsx
@@ -1,5 +1,5 @@
 import { Txt } from '@sambad/sds/components';
-import { colors } from '@sds/theme';
+import { colors } from '@sambad/sds/theme';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { Avatar } from '@/common/components/Avatar/Avatar';

--- a/packages/web-domains/src/relay-question/features/select-relay-question/components/Skeleton/NextQuestionerListSkeleton.tsx
+++ b/packages/web-domains/src/relay-question/features/select-relay-question/components/Skeleton/NextQuestionerListSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@sds/components';
+import { Skeleton } from '@sambad/sds/components';
 
 export const NextQuestionerListSkeleton = () => {
   return (

--- a/packages/web-domains/src/relay-question/features/select-relay-question/components/Skeleton/QuestionListSkeleton.tsx
+++ b/packages/web-domains/src/relay-question/features/select-relay-question/components/Skeleton/QuestionListSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@sds/components';
+import { Skeleton } from '@sambad/sds/components';
 
 export const QuestionListSkeleton = () => {
   return (

--- a/packages/web-domains/src/result/features/main/components/SelectedDataCard/Profile.tsx
+++ b/packages/web-domains/src/result/features/main/components/SelectedDataCard/Profile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Txt, TxtProps } from '@sambad/sds/components';
-import { borderRadiusVariants } from '@sds/theme';
+import { borderRadiusVariants } from '@sambad/sds/theme';
 import { HTMLAttributes } from 'react';
 
 import { Avatar } from '@/common/components/Avatar/Avatar';

--- a/packages/web-domains/src/user/features/get-user-info/components/Checkbox/CheckboxLabel.tsx
+++ b/packages/web-domains/src/user/features/get-user-info/components/Checkbox/CheckboxLabel.tsx
@@ -1,5 +1,5 @@
-import { Txt } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Txt } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 
 import { itemCss } from './styles';
 

--- a/packages/web-domains/src/user/features/get-user-info/components/Radio/RadioLabel.tsx
+++ b/packages/web-domains/src/user/features/get-user-info/components/Radio/RadioLabel.tsx
@@ -1,5 +1,5 @@
-import { Txt } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Txt } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 
 import { itemCss } from './styles';
 

--- a/packages/web-domains/src/user/features/modify-user-info/components/ModifyIntroForm.tsx
+++ b/packages/web-domains/src/user/features/modify-user-info/components/ModifyIntroForm.tsx
@@ -1,5 +1,5 @@
-import { Txt, Button } from '@sds/components';
-import { colors } from '@sds/theme';
+import { Txt, Button } from '@sambad/sds/components';
+import { colors } from '@sambad/sds/theme';
 import { useSearchParams } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 

--- a/packages/web-domains/tsconfig.json
+++ b/packages/web-domains/tsconfig.json
@@ -4,8 +4,7 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@sds/*": ["../core/sds/src/*"]
+      "@/*": ["./src/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## 🎉 변경 사항

### ✔️ tsconfig 내 불필요한 내용 제거

- 불필요하게 추가 되어있는 내용을 제거합니다.

### ✔️ sds 내 절대경로 alias 걷어내기

- sds 내부에서 절대경로 alias를 주었기 때문에
- 빌드 대상인 `web` 패키지에서도 절대경로를 명시해주었었어요.
- sds가 정말 하나의 디자인 시스템으로 오픈소스가 된다고 한다면
- 사용처에서 이를 명시해주는 것이 말이 안된다고 생각 들더군요...?
- 저희랑 비슷한 폴더 구조를 띈 [`chakra-ui`](https://github.com/chakra-ui/chakra-ui/tree/main/packages/react) 에서도 **모두 상대경로를 사용**하고 있어 저희 sds에도 차용 하게 되었습니다.

### ✔️ 이로인해 혼재되어 사용되던 import 문 정리

- 여기저기 tsconfig에 `@sds/*`가 추가되어 혼재되어 사용되고 있었습니다.
- 이를 정리합니다.

👇 in web-domains
```tsx
// as-is
import { Button } from '@sds/components'

// to-be
import { Button } from '@sambad/sds/components'
```

## 🔗 링크

#### 🙏 여기는 꼭 봐주세요!
